### PR TITLE
Pin deploy workflow actions to commit SHAs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,15 +13,20 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v5
+      # Actions are pinned to a full commit SHA (org policy); kept in sync with ci.yml.
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
         with:
           version: 11.9.0
-      - uses: actions/setup-node@v6
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: lts/*
+          node-version: 22
           cache: pnpm
+
       - run: pnpm install --frozen-lockfile
+
       # VOID_PROJECT is required because the project link in `.void/` is
       # gitignored, so there is nothing to resolve from in CI.
       - run: pnpm exec void deploy


### PR DESCRIPTION
The org requires actions pinned to full commit SHAs. The deploy workflow scaffolded with `@v6`/`@v5` tags, which fails at "Set up job". Pin checkout/setup-node/pnpm to the same SHAs ci.yml uses.