### PR TITLE
Bump publish action runtime to node24

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -35,7 +35,7 @@ outputs:
   version:
     description: 'The synthetic version published (0.0.0-commit.<sha>).'
 runs:
-  using: 'node20'
+  using: 'node24'
   # Bundle lives under .github/actions/ (built by `pnpm build:action`); this
   # action.yml is at the repo root so it can be used as `<owner>/<repo>@<ref>`.
   main: '.github/actions/publish-preview/dist/index.mjs'


### PR DESCRIPTION
GitHub is [deprecating node20](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/) for actions; runners now default to node24. Update `action.yml` `runs.using` node20 -> node24 to silence the warning and pin a supported runtime. The bundle (esbuild `target: node20`) is forward-compatible, so no rebuild is needed.