### PR TITLE
Point bun-validation example at the void.app bridge

### DIFF
--- a/examples/bun-validation/bunfig.toml
+++ b/examples/bun-validation/bunfig.toml
@@ -1,5 +1,5 @@
 [install]
-registry = "https://pkg-pr-registry-bridge.render.vip/"
+registry = "https://pkg-pr-registry-bridge.void.app/"
 
 # Bun's default network concurrency (48) triggers an HTTP/2 client bug against
 # Cloudflare on large dependency graphs (vite-plus pulls 400+ packages): streams


### PR DESCRIPTION
The bridge moved from render.vip to the Void platform URL. Update the example's default registry in `bunfig.toml`. Verified with a fresh `bun install` against void.app: the alias/override resolves to `@voidzero-dev/vite-plus-core@0.0.0-commit.6acea…` (424 packages, lockfile references void.app). `bun.lock` stays gitignored.