### PR TITLE
Serve the packument time field (fix ERR_PNPM_MISSING_TIME)

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -31,6 +31,14 @@ import {
   tarballCacheControl,
 } from './cache/headers'
 
+/**
+ * Fallback `time` (release date) for a preview registered but not yet published
+ * (or a platform binary before CI warms it). A fixed past date: deterministic
+ * across requests, and old enough that `minimum-release-age` never filters a
+ * pinned preview during that gap.
+ */
+const UNPUBLISHED_PREVIEW_TIME = '2020-01-01T00:00:00.000Z'
+
 type HonoEnv = { Bindings: Env }
 
 export const app = new Hono<HonoEnv>()
@@ -146,6 +154,10 @@ app.post('/-/publish', async (c) => {
   for (const pkg of packages) {
     assertPreviewTarget(c.env, pkg.name ?? '', pkg.version ?? '', 400)
   }
+  // Stamp the publish time server-side (when the action submits), so every
+  // package in this run shares one immutable release date. Any client-reported
+  // time is ignored.
+  const publishedAt = new Date().toISOString()
   const published = await Promise.all(
     packages.map((pkg) => {
       const name = pkg.name!
@@ -154,6 +166,7 @@ app.post('/-/publish', async (c) => {
         packageJson: pkg.packageJson ?? { name, version },
         shasum: pkg.shasum ?? '',
         integrity: pkg.integrity ?? '',
+        publishedAt,
       }
       return c.env.STORAGE.put(metaKey(name, version), JSON.stringify(meta), {
         httpMetadata: {
@@ -307,14 +320,11 @@ app.get('*', async (c) => {
   packument.versions ??= {}
 
   // pnpm's time-based resolution (`minimum-release-age`) hard-errors without a
-  // `time` map (ERR_PNPM_MISSING_TIME). Seed it from npm's real publish times,
-  // then add an entry for each injected preview version below. Exact-pinned
-  // `0.0.0-commit.*` prereleases aren't filtered by minimum-release-age, so the
-  // value just has to exist and be a valid ISO-8601 timestamp.
+  // `time` map (ERR_PNPM_MISSING_TIME). Seed it from npm's real publish times;
+  // each injected preview version's entry is its server-stamped publish time
+  // (UNPUBLISHED_PREVIEW_TIME until published), added in the loop below.
   const time: Record<string, string> = { ...(npmTime ?? {}) }
   packument.time = time
-  const previewTime =
-    time.modified ?? time.created ?? new Date().toISOString()
 
   // Inject each configured ref. The R2 meta reads are independent, so run them
   // concurrently; each writes a distinct version/tag/time key, and a failing
@@ -331,7 +341,7 @@ app.get('*', async (c) => {
           preview,
         )
         packument['dist-tags'][ref.tag] = ref.version
-        time[ref.version] = previewTime
+        time[ref.version] = preview.publishedAt ?? UNPUBLISHED_PREVIEW_TIME
       } catch (err) {
         console.warn(`Failed to inject preview ref ${ref.version}:`, err)
       }

--- a/src/app.ts
+++ b/src/app.ts
@@ -16,7 +16,7 @@ import {
   parseTarballPath,
   parseUploadPath,
 } from './registry/parsePackageName'
-import { fetchNpmPackument } from './registry/fetchNpmPackument'
+import { fetchNpmPackument, fetchNpmTime } from './registry/fetchNpmPackument'
 import { buildVersionMetadata } from './registry/buildVersionMetadata'
 import { redirectToNpm } from './registry/redirectToNpm'
 import {
@@ -287,9 +287,13 @@ app.get('*', async (c) => {
   const { name } = pkgReq
   if (!isWorkspacePackage(name, c.env)) return redirectToNpm(c.env, c.req.raw)
 
-  // The npm fetch and the refs read are independent; overlap them.
-  const [base, refs] = await Promise.all([
+  // The npm packument fetch, the npm `time` fetch, and the refs read are all
+  // independent; overlap them. `time` comes from npm's FULL packument (the
+  // abbreviated form we serve omits it) but is sourced separately so the served
+  // response keeps the compact abbreviated version docs.
+  const [base, npmTime, refs] = await Promise.all([
     fetchNpmPackument(c.env, name),
+    fetchNpmTime(c.env, name),
     getConfiguredRefs(c.env),
   ])
 
@@ -302,10 +306,20 @@ app.get('*', async (c) => {
   packument['dist-tags'] ??= {}
   packument.versions ??= {}
 
+  // pnpm's time-based resolution (`minimum-release-age`) hard-errors without a
+  // `time` map (ERR_PNPM_MISSING_TIME). Seed it from npm's real publish times,
+  // then add an entry for each injected preview version below. Exact-pinned
+  // `0.0.0-commit.*` prereleases aren't filtered by minimum-release-age, so the
+  // value just has to exist and be a valid ISO-8601 timestamp.
+  const time: Record<string, string> = { ...(npmTime ?? {}) }
+  packument.time = time
+  const previewTime =
+    time.modified ?? time.created ?? new Date().toISOString()
+
   // Inject each configured ref. The R2 meta reads are independent, so run them
-  // concurrently; each writes a distinct version/tag key, and a failing ref is
-  // isolated so it can't break installs of the package's other versions. After
-  // the deploy-time warm step these are R2 hits and don't touch the upstream.
+  // concurrently; each writes a distinct version/tag/time key, and a failing
+  // ref is isolated so it can't break installs of the package's other versions.
+  // After the deploy-time warm step these are R2 hits and don't touch upstream.
   await Promise.all(
     refs.map(async (ref) => {
       try {
@@ -317,6 +331,7 @@ app.get('*', async (c) => {
           preview,
         )
         packument['dist-tags'][ref.tag] = ref.version
+        time[ref.version] = previewTime
       } catch (err) {
         console.warn(`Failed to inject preview ref ${ref.version}:`, err)
       }

--- a/src/registry/fetchNpmPackument.ts
+++ b/src/registry/fetchNpmPackument.ts
@@ -25,6 +25,14 @@ const ABBREVIATED_ACCEPT = 'application/vnd.npm.install-v1+json'
 // reaches a package manager's HTTP/2 client.
 const FULL_ACCEPT = 'application/json'
 
+/** GET a package's metadata from the npm registry with the given Accept header. */
+function npmFetch(env: Env, name: string, accept: string): Promise<Response> {
+  return fetch(`${env.NPM_REGISTRY}/${encodeNpmPackageName(name)}`, {
+    headers: { accept },
+    redirect: 'follow',
+  })
+}
+
 /**
  * Fetch a packument from the npm registry. A 404 (package not published to
  * npm) is returned as `{ status: 404, data: null }` so the caller can still
@@ -34,10 +42,7 @@ export async function fetchNpmPackument(
   env: Env,
   name: string,
 ): Promise<NpmPackumentResult> {
-  const res = await fetch(`${env.NPM_REGISTRY}/${encodeNpmPackageName(name)}`, {
-    headers: { accept: ABBREVIATED_ACCEPT },
-    redirect: 'follow',
-  })
+  const res = await npmFetch(env, name, ABBREVIATED_ACCEPT)
 
   if (res.status === 404) return { status: 404, data: null }
   if (!res.ok) return { status: res.status, data: null }
@@ -62,10 +67,7 @@ export async function fetchNpmTime(
   // error return null and serve without npm's times (the injected preview
   // versions still get their own `time` entry from the caller).
   try {
-    const res = await fetch(`${env.NPM_REGISTRY}/${encodeNpmPackageName(name)}`, {
-      headers: { accept: FULL_ACCEPT },
-      redirect: 'follow',
-    })
+    const res = await npmFetch(env, name, FULL_ACCEPT)
 
     if (!res.ok) return null
 

--- a/src/registry/fetchNpmPackument.ts
+++ b/src/registry/fetchNpmPackument.ts
@@ -16,6 +16,15 @@ export interface NpmPackumentResult {
 // to install, and is what package managers want anyway.
 const ABBREVIATED_ACCEPT = 'application/vnd.npm.install-v1+json'
 
+// Full packument format. The abbreviated form above omits the per-version
+// `time` map by spec, but pnpm's time-based resolution (`minimum-release-age`)
+// hard-errors without it (ERR_PNPM_MISSING_TIME). We request the full
+// packument ONLY to source `time` (see fetchNpmTime); the served response keeps
+// using the compact abbreviated version docs, so it stays small. This fetch is
+// server-side (Worker→npm) and edge-cached, so the large full payload never
+// reaches a package manager's HTTP/2 client.
+const FULL_ACCEPT = 'application/json'
+
 /**
  * Fetch a packument from the npm registry. A 404 (package not published to
  * npm) is returned as `{ status: 404, data: null }` so the caller can still
@@ -35,4 +44,37 @@ export async function fetchNpmPackument(
 
   const data = (await res.json()) as Record<string, any>
   return { status: 200, data }
+}
+
+/**
+ * Fetch ONLY the per-version `time` map from npm's FULL packument. Returns null
+ * when the package is absent (404) or the upstream omits/has no usable `time`,
+ * so the caller can still serve a synthesized packument (with `time` entries it
+ * fills in for the injected preview versions). Keeping this separate from
+ * fetchNpmPackument lets the served response carry the compact abbreviated
+ * version docs while still preserving npm's real publish times.
+ */
+export async function fetchNpmTime(
+  env: Env,
+  name: string,
+): Promise<Record<string, string> | null> {
+  // Fail soft: a hiccup sourcing `time` must not break the packument. On any
+  // error return null and serve without npm's times (the injected preview
+  // versions still get their own `time` entry from the caller).
+  try {
+    const res = await fetch(`${env.NPM_REGISTRY}/${encodeNpmPackageName(name)}`, {
+      headers: { accept: FULL_ACCEPT },
+      redirect: 'follow',
+    })
+
+    if (!res.ok) return null
+
+    const data = (await res.json()) as Record<string, any>
+    const time = data?.time
+    return time && typeof time === 'object'
+      ? (time as Record<string, string>)
+      : null
+  } catch {
+    return null
+  }
 }

--- a/src/tarball/buildPreviewTarball.ts
+++ b/src/tarball/buildPreviewTarball.ts
@@ -32,6 +32,12 @@ export interface PreviewMeta {
   shasum: string
   /** SHA-512 SRI of the generated tarball, for `dist.integrity`. */
   integrity: string
+  /**
+   * ISO-8601 timestamp stamped server-side when this build was published, used
+   * as the version's `time` (release date) in the packument. Optional for
+   * back-compat with metas stored before this field existed.
+   */
+  publishedAt?: string
 }
 
 export interface PreviewBuild extends PreviewMeta {

--- a/src/tarball/getPreviewBuild.ts
+++ b/src/tarball/getPreviewBuild.ts
@@ -26,7 +26,7 @@ async function buildAndStore(
   env: Env,
   name: string,
   version: string,
-): Promise<PreviewBuild> {
+): Promise<PreviewBuild & { publishedAt: string }> {
   const url = toPkgPrNewUrl(env, name, version)
   if (!url) throw new HttpError(400, `Invalid preview version: ${version}`)
 
@@ -34,10 +34,14 @@ async function buildAndStore(
   const build = await buildPreviewTarball(upstream, name, version, env)
   const cacheControl = tarballCacheControl()
 
+  // Stamp the build time server-side, so the on-demand path reports the same
+  // release date as a CI publish (and the same value on every later read).
+  const publishedAt = new Date().toISOString()
   const meta: PreviewMeta = {
     packageJson: build.packageJson,
     shasum: build.shasum,
     integrity: build.integrity,
+    publishedAt,
   }
   await Promise.all([
     env.STORAGE.put(tarballKey(name, version), build.tarball, {
@@ -48,7 +52,7 @@ async function buildAndStore(
     }),
   ])
 
-  return build
+  return { ...build, publishedAt }
 }
 
 /**
@@ -99,6 +103,7 @@ export async function getPreviewMeta(
     packageJson: build.packageJson,
     shasum: build.shasum,
     integrity: build.integrity,
+    publishedAt: build.publishedAt,
   }
 }
 

--- a/test/worker.test.ts
+++ b/test/worker.test.ts
@@ -163,6 +163,50 @@ describe('packument endpoint', () => {
     expect(body.time['0.0.0-commit.a832a55']).toBeTruthy()
   })
 
+  it('stamps the preview release date server-side at publish, stable across requests', async () => {
+    // The release date is stamped server-side once at publish, not npm's
+    // package-modified time, not a per-request clock, and not a client value.
+    const sha = 'feedfacefeedfacefeedfacefeedfacefeedface'
+    const ver = `0.0.0-commit.${sha}`
+    const before = Date.now()
+    const pub = await SELF.fetch(`${BASE}/-/publish`, {
+      method: 'POST',
+      headers: { ...AUTH, 'content-type': 'application/json' },
+      body: JSON.stringify({
+        ref: `commit.${sha}`,
+        // A client-reported time must be ignored in favor of the server's.
+        publishedAt: '2000-01-01T00:00:00.000Z',
+        packages: [
+          {
+            name: '@voidzero-dev/vite-plus-core',
+            version: ver,
+            packageJson: { name: '@voidzero-dev/vite-plus-core', version: ver },
+            integrity: 'sha512-test',
+            shasum: '',
+          },
+        ],
+      }),
+    })
+    expect(pub.status).toBe(201)
+
+    const timeFor = async () =>
+      (
+        (await (
+          await SELF.fetch(`${BASE}/@voidzero-dev%2Fvite-plus-core`, {
+            headers: { accept: 'application/json' },
+          })
+        ).json()) as Record<string, any>
+      ).time?.[ver]
+
+    const t1 = await timeFor()
+    const t2 = await timeFor()
+    expect(t1).toBeTruthy()
+    expect(t1).toBe(t2) // stamped once at publish, identical across requests
+    // server's time, not the bogus client value, and not the unpublished fallback
+    expect(t1).not.toBe('2000-01-01T00:00:00.000Z')
+    expect(Date.parse(t1)).toBeGreaterThanOrEqual(before)
+  })
+
   it('synthesizes a preview-only packument when npm has no such package', async () => {
     const res = await SELF.fetch(`${BASE}/@voidzero-dev%2Fvite-plus-core`, {
       headers: { accept: 'application/json' },

--- a/test/worker.test.ts
+++ b/test/worker.test.ts
@@ -25,6 +25,14 @@ const NPM_VITE_PLUS = {
   },
 }
 
+// Real npm only returns the per-version `time` map in the FULL packument
+// (`Accept: application/json`), never in the abbreviated (install-v1) form.
+const NPM_VITE_PLUS_TIME = {
+  created: '2024-01-01T00:00:00.000Z',
+  modified: '2026-06-18T05:33:32.399Z',
+  '0.2.1': '2026-06-18T05:33:32.399Z',
+}
+
 function json(obj: unknown, status = 200): Response {
   return new Response(JSON.stringify(obj), {
     status,
@@ -68,11 +76,24 @@ beforeAll(async () => {
     dependencies: { 'vite-plus': 'a832a55' },
   })
 
-  const mockFetch = (input: RequestInfo | URL): Promise<Response> => {
+  const mockFetch = (
+    input: RequestInfo | URL,
+    init?: RequestInit,
+  ): Promise<Response> => {
     const url = typeof input === 'string' ? input : input.toString()
 
     if (url === 'https://registry.npmjs.org/vite-plus') {
-      return Promise.resolve(json(NPM_VITE_PLUS))
+      // Mimic npm: `time` is present only in the full packument, not the
+      // abbreviated (install-v1) form. Branch on the Accept header.
+      const h = init?.headers
+      const accept = (
+        h instanceof Headers ? h.get('accept') : (h as Record<string, string>)?.accept
+      ) ?? ''
+      const abbreviated = accept.includes('install-v1')
+      const body = abbreviated
+        ? { ...NPM_VITE_PLUS, modified: NPM_VITE_PLUS_TIME.modified }
+        : { ...NPM_VITE_PLUS, time: NPM_VITE_PLUS_TIME }
+      return Promise.resolve(json(body))
     }
     if (url.startsWith('https://registry.npmjs.org/@voidzero-dev')) {
       return Promise.resolve(json({ error: 'Not found' }, 404))
@@ -125,6 +146,23 @@ describe('packument endpoint', () => {
     expect(res.headers.get('cache-control')).toContain('max-age=300')
   })
 
+  it('includes a `time` field with npm publish times and the preview version', async () => {
+    // Reproduces ERR_PNPM_MISSING_TIME: pnpm's time-based resolution (e.g.
+    // `minimum-release-age`) needs `time`. npm only exposes it in the full
+    // packument, and each injected preview version needs its own entry too.
+    const res = await SELF.fetch(`${BASE}/vite-plus`, {
+      headers: { accept: 'application/json' },
+    })
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as Record<string, any>
+
+    expect(body.time).toBeTruthy()
+    // npm's real publish time is preserved (requires sourcing the full packument).
+    expect(body.time['0.2.1']).toBe('2026-06-18T05:33:32.399Z')
+    // the injected preview version carries a time entry, or pnpm hard-errors.
+    expect(body.time['0.0.0-commit.a832a55']).toBeTruthy()
+  })
+
   it('synthesizes a preview-only packument when npm has no such package', async () => {
     const res = await SELF.fetch(`${BASE}/@voidzero-dev%2Fvite-plus-core`, {
       headers: { accept: 'application/json' },
@@ -140,6 +178,9 @@ describe('packument endpoint', () => {
     expect(preview.dist.tarball).toBe(
       `${BASE}/tarballs/@voidzero-dev/vite-plus-core/0.0.0-commit.a832a55.tgz`,
     )
+    // A synthesized (not-on-npm) packument still needs `time` for the preview,
+    // or pnpm errors with ERR_PNPM_MISSING_TIME.
+    expect(body.time?.['0.0.0-commit.a832a55']).toBeTruthy()
   })
 
   it('rewrites pkg.pr.new optionalDependency URLs to version strings', async () => {


### PR DESCRIPTION
The bridge fetched only the abbreviated npm packument (which omits the per-version `time` map) and never added `time` for injected preview versions, so pnpm's `minimum-release-age` resolution failed with `ERR_PNPM_MISSING_TIME`.

Source `time` from npm's full packument via a separate, parallel, fail-soft fetch (the served response keeps the compact abbreviated version docs), and add an entry for each injected preview version (incl. the synthesized not-on-npm case). Reproducing test written first; 55 tests pass.