### PR TITLE
Tidy docs: drop redundant README Status, mark RFC historical

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,13 +240,3 @@ add at your DNS provider) and set `PUBLIC_BASE_URL` to that host.
 Pushes to `main` auto-deploy via `.github/workflows/deploy.yml` (`pnpm exec void
 deploy`). Add a `VOID_TOKEN` repository secret (`void auth token` copies one to
 your clipboard); `VOID_PROJECT` is pinned in the workflow.
-
-## Status
-
-Deployed: default-registry bridge with npm redirect fallback, `commit.<sha>`
-preview injection, R2-served tarballs with SHA-512/SHA-1 integrity, CI-side
-build/hash/upload via the [publish action](#publishing-from-ci) (the Worker
-never decompresses or hashes), R2-backed dynamic refs (a single index object, no
-rate-limited KV list), authenticated admin
-endpoints (`/-/refs`, `/-/purge`, `/-/publish`, `/-/tarball`), and optional
-GitHub existence checks, plus a bun end-to-end check.

--- a/rfcs/0001-pkg-pr-new-registry-bridge-cloudflare-workers.md
+++ b/rfcs/0001-pkg-pr-new-registry-bridge-cloudflare-workers.md
@@ -13,6 +13,11 @@
 > overwritten and mismatch a consumer's lockfile. Read `pr.<n>` examples as
 > historical design; use `commit.<sha>` for current behavior.
 
+> Deployment note: the bridge has since migrated to the [Void](https://void.cloud)
+> framework and deploys via `void deploy`; the wrangler / own-Cloudflare-account
+> and `GITHUB_TOKEN` specifics below are historical. See [README.md](../README.md)
+> for the current implementation and deployment.
+
 ## 1. Summary
 
 This RFC specifies how to implement the version-gated pkg.pr.new registry


### PR DESCRIPTION
From `/simplify`. The README `## Status` section duplicated How it works / Publishing from CI and still listed the now-removed GitHub existence checks, so remove it. Add a one-line 'migrated to Void' note to the historical RFC so its wrangler/GITHUB_TOKEN content isn't read as current.