### PR TITLE
Make registry-bridge.viteplus.dev the canonical bridge URL

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -4,4 +4,4 @@
 
 # Public origin of the deployed bridge (the Void platform URL). Update this if a
 # custom domain is later attached with `void domain add`.
-PUBLIC_BASE_URL=https://pkg-pr-registry-bridge.void.app
+PUBLIC_BASE_URL=https://registry-bridge.viteplus.dev

--- a/.github/actions/publish-preview/dist/index.mjs
+++ b/.github/actions/publish-preview/dist/index.mjs
@@ -566,7 +566,7 @@ async function main() {
   const [parsed] = parseConfiguredPreviewRefs(`commit.${rawSha}`);
   const ref = `commit.${parsed.ref}`;
   const version = parsed.version;
-  const bridge = (input("bridge-url") || "https://pkg-pr-registry-bridge.void.app").replace(/\/+$/, "");
+  const bridge = (input("bridge-url") || "https://registry-bridge.viteplus.dev").replace(/\/+$/, "");
   const token = input("admin-token", true);
   const env = {
     PUBLIC_BASE_URL: bridge,

--- a/.github/actions/publish-preview/src/index.ts
+++ b/.github/actions/publish-preview/src/index.ts
@@ -90,7 +90,7 @@ async function main(): Promise<void> {
   const [parsed] = parseConfiguredPreviewRefs(`commit.${rawSha}`)
   const ref = `commit.${parsed.ref}`
   const version = parsed.version
-  const bridge = (input('bridge-url') || 'https://pkg-pr-registry-bridge.void.app').replace(/\/+$/, '')
+  const bridge = (input('bridge-url') || 'https://registry-bridge.viteplus.dev').replace(/\/+$/, '')
   const token = input('admin-token', true)
   const env: RewriteEnv = {
     PUBLIC_BASE_URL: bridge,

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A version-gated npm registry bridge that lets package managers install
 [pkg.pr.new](https://pkg.pr.new) Vite+ preview builds using normal npm registry
 semantics. Runs as a single Cloudflare Worker.
 
-Live: `https://pkg-pr-registry-bridge.void.app`
+Live: `https://registry-bridge.viteplus.dev`
 
 The package name selects the upstream package; the version pattern selects the
 source:
@@ -83,7 +83,7 @@ versions (strict allowlist). Owner/repo are fixed to `voidzero-dev/vite-plus`.
 
 ```toml
 [install]
-registry = "https://pkg-pr-registry-bridge.void.app/"
+registry = "https://registry-bridge.viteplus.dev/"
 
 # REQUIRED for large installs. Bun's default network concurrency (48) triggers
 # an HTTP/2 client bug against Cloudflare on big dependency graphs (vite-plus
@@ -232,10 +232,10 @@ preview refs into R2 via the action so installs are served from cache), then
 alias/override resolves to the synthetic version). Use `pnpm run deploy:only`
 for `void deploy` alone.
 
-The public origin (`PUBLIC_BASE_URL` in `.env.production`) is the Void platform
-URL `https://pkg-pr-registry-bridge.void.app`. To serve from a custom domain
-instead, run `void domain add <hostname>` (it prints the CNAME + ownership TXT to
-add at your DNS provider) and set `PUBLIC_BASE_URL` to that host.
+The public origin (`PUBLIC_BASE_URL` in `.env.production`) is the custom domain
+`https://registry-bridge.viteplus.dev`, attached with `void domain add` (the
+underlying Void platform URL `pkg-pr-registry-bridge.void.app` keeps working
+too).
 
 Pushes to `main` auto-deploy via `.github/workflows/deploy.yml` (`pnpm exec void
 deploy`). Add a `VOID_TOKEN` repository secret (`void auth token` copies one to

--- a/action.yml
+++ b/action.yml
@@ -11,7 +11,7 @@ inputs:
   bridge-url:
     description: 'Base URL of the registry bridge.'
     required: false
-    default: 'https://pkg-pr-registry-bridge.void.app'
+    default: 'https://registry-bridge.viteplus.dev'
   admin-token:
     description: 'Bridge ADMIN_TOKEN (store as a secret).'
     required: true

--- a/docs/ci-setup.md
+++ b/docs/ci-setup.md
@@ -1,6 +1,6 @@
 # Wiring vite-plus CI to the registry bridge
 
-Bridge: `https://pkg-pr-registry-bridge.void.app`
+Bridge: `https://registry-bridge.viteplus.dev`
 Repo:   `voidzero-dev/vite-plus` (owner/repo are fixed in the Worker)
 
 > Keep the real `ADMIN_TOKEN` in a password manager / Actions secret, not in the
@@ -33,7 +33,7 @@ Right after the pkg.pr.new build publishes:
   with:
     sha: ${{ github.event.pull_request.head.sha }}
     admin-token: ${{ secrets.PKG_PR_BRIDGE_ADMIN_TOKEN }}
-    # bridge-url defaults to https://pkg-pr-registry-bridge.void.app
+    # bridge-url defaults to https://registry-bridge.viteplus.dev
 ```
 
 > Use `github.event.pull_request.head.sha`, not `github.sha`. pkg.pr.new publishes
@@ -47,7 +47,7 @@ Right after the pkg.pr.new build publishes:
 After a PR build publishes and the step runs:
 
 ```bash
-curl https://pkg-pr-registry-bridge.void.app/-/refs
+curl https://registry-bridge.viteplus.dev/-/refs
 ```
 
 ## Notes

--- a/examples/bun-validation/bunfig.toml
+++ b/examples/bun-validation/bunfig.toml
@@ -1,5 +1,5 @@
 [install]
-registry = "https://pkg-pr-registry-bridge.void.app/"
+registry = "https://registry-bridge.viteplus.dev/"
 
 # Bun's default network concurrency (48) triggers an HTTP/2 client bug against
 # Cloudflare on large dependency graphs (vite-plus pulls 400+ packages): streams


### PR DESCRIPTION
The custom domain `registry-bridge.viteplus.dev` is live (added with `void domain add`). Point `PUBLIC_BASE_URL` (packument `dist.tarball` URLs), the publish action default, docs, and the bun example at it. The `pkg-pr-registry-bridge.void.app` platform URL keeps working.