### PR TITLE
Add publishedAt and prUrl to /-/refs; drop the unused dist-tag

### DIFF
--- a/.github/actions/publish-preview/dist/index.mjs
+++ b/.github/actions/publish-preview/dist/index.mjs
@@ -504,8 +504,7 @@ function parseSingleRef(value) {
   return {
     type: "commit",
     ref: commit[1],
-    version: commitVersion(commit[1]),
-    tag: `commit-${commit[1]}`
+    version: commitVersion(commit[1])
   };
 }
 function splitRefs(input2) {
@@ -568,6 +567,7 @@ async function main() {
   const version = parsed.version;
   const bridge = (input("bridge-url") || "https://registry-bridge.viteplus.dev").replace(/\/+$/, "");
   const token = input("admin-token", true);
+  const prUrl = input("pr-url") || void 0;
   const env = {
     PUBLIC_BASE_URL: bridge,
     PKG_PR_NEW_BASE: (input("pkg-pr-new-base") || "https://pkg.pr.new").replace(/\/+$/, ""),
@@ -607,7 +607,7 @@ async function main() {
     const res = await fetch(`${bridge}/-/publish`, {
       method: "POST",
       headers: { authorization: `Bearer ${token}`, "content-type": "application/json" },
-      body: JSON.stringify({ ref, packages })
+      body: JSON.stringify({ ref, prUrl, packages })
     });
     if (!res.ok) throw new Error(`HTTP ${res.status}: ${await res.text().catch(() => "")}`);
   });

--- a/.github/actions/publish-preview/src/index.ts
+++ b/.github/actions/publish-preview/src/index.ts
@@ -92,6 +92,8 @@ async function main(): Promise<void> {
   const version = parsed.version
   const bridge = (input('bridge-url') || 'https://registry-bridge.viteplus.dev').replace(/\/+$/, '')
   const token = input('admin-token', true)
+  // Optional: present on pull_request runs, empty on push/commit runs.
+  const prUrl = input('pr-url') || undefined
   const env: RewriteEnv = {
     PUBLIC_BASE_URL: bridge,
     PKG_PR_NEW_BASE: (input('pkg-pr-new-base') || 'https://pkg.pr.new').replace(/\/+$/, ''),
@@ -143,7 +145,7 @@ async function main(): Promise<void> {
     const res = await fetch(`${bridge}/-/publish`, {
       method: 'POST',
       headers: { authorization: `Bearer ${token}`, 'content-type': 'application/json' },
-      body: JSON.stringify({ ref, packages }),
+      body: JSON.stringify({ ref, prUrl, packages }),
     })
     if (!res.ok) throw new Error(`HTTP ${res.status}: ${await res.text().catch(() => '')}`)
   })

--- a/README.md
+++ b/README.md
@@ -137,7 +137,9 @@ with `void secret put ADMIN_TOKEN`); without it configured the write endpoints
 return 503. `GET /-/refs` is a public read.
 
 ```bash
-# List configured refs (static env + runtime R2 index) - no auth required
+# List configured refs (static env + runtime R2 index) - no auth required.
+# Each entry: { ref, version, publishedAt, prUrl }; publishedAt/prUrl are null
+# until the ref is published (and prUrl only when published from a PR).
 curl https://.../-/refs
 
 # Register a ref at runtime (no redeploy).

--- a/action.yml
+++ b/action.yml
@@ -15,6 +15,12 @@ inputs:
   admin-token:
     description: 'Bridge ADMIN_TOKEN (store as a secret).'
     required: true
+  pr-url:
+    description: >-
+      URL of the source pull request, surfaced by /-/refs. Optional: pass
+      github.event.pull_request.html_url on pull_request runs; leave empty on
+      push/commit runs.
+    required: false
   pkg-pr-new-base:
     description: 'pkg.pr.new base URL.'
     required: false

--- a/docs/ci-setup.md
+++ b/docs/ci-setup.md
@@ -33,6 +33,8 @@ Right after the pkg.pr.new build publishes:
   with:
     sha: ${{ github.event.pull_request.head.sha }}
     admin-token: ${{ secrets.PKG_PR_BRIDGE_ADMIN_TOKEN }}
+    # Optional: surfaced by /-/refs. Omit/empty on push runs (no PR).
+    pr-url: ${{ github.event.pull_request.html_url }}
     # bridge-url defaults to https://registry-bridge.viteplus.dev
 ```
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -136,6 +136,7 @@ app.post('/-/publish', async (c) => {
   admin(c)
   const body = (await c.req.json().catch(() => ({}))) as {
     ref?: string
+    prUrl?: string
     packages?: Array<{
       name?: string
       version?: string
@@ -145,6 +146,8 @@ app.post('/-/publish', async (c) => {
     }>
   }
   const ref = (body.ref ?? '').trim()
+  // Optional: the action runs on push commits too, where there is no PR.
+  const prUrl = (body.prUrl ?? '').trim() || undefined
   const packages = Array.isArray(body.packages) ? body.packages : []
   if (!ref) throw new HttpError(400, 'Missing ref')
   if (packages.length === 0) throw new HttpError(400, 'Missing packages')
@@ -179,8 +182,9 @@ app.post('/-/publish', async (c) => {
 
   let parsed
   try {
-    // registerRef parses + validates the ref and returns it.
-    parsed = await registerRef(c.env, ref)
+    // registerRef parses + validates the ref and returns it. Record this run's
+    // server-stamped publish time and (when present) the source PR url.
+    parsed = await registerRef(c.env, ref, { publishedAt, prUrl })
   } catch (err) {
     throw new HttpError(400, `Invalid or unregisterable ref: ${ref} (${err})`)
   }
@@ -194,7 +198,8 @@ app.get('/-/refs', async (c) => {
     refs: refs.map((r) => ({
       ref: `${r.type}.${r.ref}`,
       version: r.version,
-      tag: r.tag,
+      publishedAt: r.publishedAt ?? null,
+      prUrl: r.prUrl ?? null,
     })),
   })
 })
@@ -223,7 +228,7 @@ app.post('/-/refs', async (c) => {
   // The tarballs/integrity are built and uploaded by the publish action (CI);
   // until then this ref's packument uses name-derived platform metas and the
   // tarball endpoint redirects platform binaries to pkg.pr.new.
-  return c.json({ added: ref, version: parsed.version, tag: parsed.tag }, 201)
+  return c.json({ added: ref, version: parsed.version }, 201)
 })
 
 /** Unregister a runtime preview ref. Body: `{ "ref": "commit.<sha>" }`. */
@@ -325,9 +330,9 @@ app.get('*', async (c) => {
   packument.time = time
 
   // Inject each configured ref. The R2 meta reads are independent, so run them
-  // concurrently; each writes a distinct version/tag/time key, and a failing
-  // ref is isolated so it can't break installs of the package's other versions.
-  // After the deploy-time warm step these are R2 hits and don't touch upstream.
+  // concurrently; each writes a distinct version/time key, and a failing ref is
+  // isolated so it can't break installs of the package's other versions. After
+  // the deploy-time warm step these are R2 hits and don't touch upstream.
   await Promise.all(
     refs.map(async (ref) => {
       try {
@@ -338,7 +343,6 @@ app.get('*', async (c) => {
           ref.version,
           preview,
         )
-        packument['dist-tags'][ref.tag] = ref.version
         time[ref.version] = preview.publishedAt ?? UNPUBLISHED_PREVIEW_TIME
       } catch (err) {
         console.warn(`Failed to inject preview ref ${ref.version}:`, err)

--- a/src/preview/getConfiguredRefs.ts
+++ b/src/preview/getConfiguredRefs.ts
@@ -16,8 +16,10 @@ import { REFS_INDEX_KEY } from '../cache/r2Cache'
 const REF_TTL_MS = 90 * 24 * 60 * 60 * 1000
 const MAX_CAS_ATTEMPTS = 6
 
-/** canonical `commit.<sha>` -> expiry (epoch ms). */
-type RefIndex = Record<string, { expiresAt: number }>
+/** Per-ref runtime state: expiry plus optional publish time and PR url. */
+type RefEntry = { expiresAt: number; publishedAt?: string; prUrl?: string }
+/** canonical `commit.<sha>` -> RefEntry. */
+type RefIndex = Record<string, RefEntry>
 
 function canonical(ref: ConfiguredPreviewRef): string {
   return `${ref.type}.${ref.ref}`
@@ -77,7 +79,10 @@ export async function getConfiguredRefs(
     const { index } = await readRefIndex(env)
     const now = Date.now()
     const live = Object.keys(index).filter((c) => index[c].expiresAt > now)
-    fromR2 = parseConfiguredPreviewRefsSafe(live.join(','))
+    fromR2 = parseConfiguredPreviewRefsSafe(live.join(',')).map((r) => {
+      const entry = index[`${r.type}.${r.ref}`]
+      return { ...r, publishedAt: entry?.publishedAt, prUrl: entry?.prUrl }
+    })
   } catch (err) {
     console.warn('Failed to read preview refs from R2:', err)
   }
@@ -91,10 +96,17 @@ export async function getConfiguredRefs(
 export async function registerRef(
   env: Env,
   ref: string,
+  extra?: { publishedAt?: string; prUrl?: string },
 ): Promise<ConfiguredPreviewRef> {
   const [parsed] = parseConfiguredPreviewRefs(ref)
   await mutateRefIndex(env, (index) => {
-    index[canonical(parsed)] = { expiresAt: Date.now() + REF_TTL_MS }
+    const existing = index[canonical(parsed)]
+    // Preserve a prior publish time / PR url when re-registering without them.
+    index[canonical(parsed)] = {
+      expiresAt: Date.now() + REF_TTL_MS,
+      publishedAt: extra?.publishedAt ?? existing?.publishedAt,
+      prUrl: extra?.prUrl ?? existing?.prUrl,
+    }
   })
   return parsed
 }

--- a/src/preview/parseConfiguredPreviewRefs.ts
+++ b/src/preview/parseConfiguredPreviewRefs.ts
@@ -14,7 +14,9 @@ export type ConfiguredPreviewRef = {
   type: 'commit'
   ref: string
   version: string
-  tag: string
+  /** Populated by getConfiguredRefs from the runtime refs index, when known. */
+  publishedAt?: string
+  prUrl?: string
 }
 
 /** Parse one trimmed ref token, or return null if it is not a commit ref. */
@@ -25,7 +27,6 @@ function parseSingleRef(value: string): ConfiguredPreviewRef | null {
     type: 'commit',
     ref: commit[1],
     version: commitVersion(commit[1]),
-    tag: `commit-${commit[1]}`,
   }
 }
 

--- a/test/unit.test.ts
+++ b/test/unit.test.ts
@@ -72,13 +72,12 @@ describe('parsePreviewVersion', () => {
 })
 
 describe('parseConfiguredPreviewRefs', () => {
-  it('parses commit refs into versions and tags', () => {
+  it('parses commit refs into versions', () => {
     expect(parseConfiguredPreviewRefs('commit.a832a55')).toEqual([
       {
         type: 'commit',
         ref: 'a832a55',
         version: '0.0.0-commit.a832a55',
-        tag: 'commit-a832a55',
       },
     ])
   })
@@ -96,7 +95,6 @@ describe('parseConfiguredPreviewRefs', () => {
         type: 'commit',
         ref: 'abcdef0',
         version: '0.0.0-commit.abcdef0',
-        tag: 'commit-abcdef0',
       },
     ])
   })

--- a/test/worker.test.ts
+++ b/test/worker.test.ts
@@ -132,7 +132,7 @@ describe('packument endpoint', () => {
     expect(body.versions['0.2.1']).toBeTruthy()
     expect(body['dist-tags'].latest).toBe('0.2.1')
 
-    // preview version + dist-tag injected.
+    // preview version injected.
     const preview = body.versions['0.0.0-commit.a832a55']
     expect(preview).toBeTruthy()
     expect(preview.version).toBe('0.0.0-commit.a832a55')
@@ -142,7 +142,6 @@ describe('packument endpoint', () => {
     expect(preview.dist.tarball).toBe(
       `${BASE}/tarballs/vite-plus/0.0.0-commit.a832a55.tgz`,
     )
-    expect(body['dist-tags']['commit-a832a55']).toBe('0.0.0-commit.a832a55')
     expect(res.headers.get('cache-control')).toContain('max-age=300')
   })
 
@@ -488,6 +487,80 @@ describe('admin: refs', () => {
     expect(body.refs.some((r) => r.ref === 'commit.a832a55')).toBe(true)
   })
 
+  it('surfaces the server-stamped publish time and PR url for a published ref', async () => {
+    const sha = 'deadbee'
+    const version = `0.0.0-commit.${sha}`
+    const prUrl = 'https://github.com/voidzero-dev/vite-plus/pull/123'
+    const pub = await SELF.fetch(`${BASE}/-/publish`, {
+      method: 'POST',
+      headers: { ...AUTH, 'content-type': 'application/json' },
+      body: JSON.stringify({
+        ref: `commit.${sha}`,
+        prUrl,
+        packages: [
+          {
+            name: 'vite-plus',
+            version,
+            packageJson: { name: 'vite-plus', version },
+            integrity: 'sha512-test',
+            shasum: '',
+          },
+        ],
+      }),
+    })
+    expect(pub.status).toBe(201)
+
+    const res = await SELF.fetch(`${BASE}/-/refs`)
+    const body = (await res.json()) as {
+      refs: Array<{
+        ref: string
+        version: string
+        publishedAt: string | null
+        prUrl: string | null
+      }>
+    }
+    const entry = body.refs.find((r) => r.ref === `commit.${sha}`)
+    expect(entry).toBeTruthy()
+    expect(entry!.version).toBe(version)
+    // server-stamped at publish, a valid ISO timestamp.
+    expect(typeof entry!.publishedAt).toBe('string')
+    expect(Number.isNaN(Date.parse(entry!.publishedAt!))).toBe(false)
+    expect(entry!.prUrl).toBe(prUrl)
+    // the old dist-tag field is gone.
+    expect(entry).not.toHaveProperty('tag')
+  })
+
+  it('omits the PR url for a ref published without one (push run)', async () => {
+    const sha = 'beefca0'
+    const version = `0.0.0-commit.${sha}`
+    const pub = await SELF.fetch(`${BASE}/-/publish`, {
+      method: 'POST',
+      headers: { ...AUTH, 'content-type': 'application/json' },
+      body: JSON.stringify({
+        ref: `commit.${sha}`,
+        packages: [
+          {
+            name: 'vite-plus',
+            version,
+            packageJson: { name: 'vite-plus', version },
+            integrity: 'sha512-test',
+            shasum: '',
+          },
+        ],
+      }),
+    })
+    expect(pub.status).toBe(201)
+
+    const res = await SELF.fetch(`${BASE}/-/refs`)
+    const body = (await res.json()) as {
+      refs: Array<{ ref: string; publishedAt: string | null; prUrl: string | null }>
+    }
+    const entry = body.refs.find((r) => r.ref === `commit.${sha}`)
+    expect(entry).toBeTruthy()
+    expect(typeof entry!.publishedAt).toBe('string')
+    expect(entry!.prUrl).toBeNull()
+  })
+
   it('registers a ref and injects it into the packument', async () => {
     const add = await SELF.fetch(`${BASE}/-/refs`, {
       method: 'POST',
@@ -505,7 +578,6 @@ describe('admin: refs', () => {
     })
     const body = (await pack.json()) as Record<string, any>
     expect(body.versions['0.0.0-commit.a832a55']).toBeTruthy()
-    expect(body['dist-tags']['commit-a832a55']).toBe('0.0.0-commit.a832a55')
   })
 
   it('rejects an invalid ref', async () => {


### PR DESCRIPTION
## Problem

`/-/refs` only listed `{ ref, version, tag }`. There was no way to see when a ref was published or which PR it came from, and the `commit-<sha>` dist-tag was unused (everything installs by exact version).

## Change

`/-/refs` now returns per ref:
- `publishedAt`: server-stamped publish time (set at `/-/publish`).
- `prUrl`: the source pull request, when published from one. Optional, `null` on push runs.

Both are stored on the ref in the R2 refs index and preserved across re-registration. The publish action forwards `github.event.pull_request.html_url` through a new optional `pr-url` input (the bridge change works on its own; `prUrl` stays `null` until CI passes it).

The `commit-<sha>` dist-tag injection and the `tag` field (refs API + parsed ref) are removed.

## Notes

- vite-plus CI needs a one-line addition to pass `pr-url: ${{ github.event.pull_request.html_url }}` (documented in `docs/ci-setup.md`); without it, refs simply have `prUrl: null`.
- 59 tests pass (added: publishedAt+prUrl surfaced, prUrl omitted on push).