### PR TITLE
Add expiresAt to /-/refs; single-pass ref resolution and honest parse type

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,8 +138,9 @@ return 503. `GET /-/refs` is a public read.
 
 ```bash
 # List configured refs (static env + runtime R2 index) - no auth required.
-# Each entry: { ref, version, publishedAt, prUrl }; publishedAt/prUrl are null
-# until the ref is published (and prUrl only when published from a PR).
+# Each entry: { ref, version, publishedAt, prUrl, expiresAt }. publishedAt/prUrl
+# are null until the ref is published (prUrl only when published from a PR);
+# expiresAt is the index TTL (null for static env refs, which never expire).
 curl https://.../-/refs
 
 # Register a ref at runtime (no redeploy).

--- a/src/app.ts
+++ b/src/app.ts
@@ -200,6 +200,8 @@ app.get('/-/refs', async (c) => {
       version: r.version,
       publishedAt: r.publishedAt ?? null,
       prUrl: r.prUrl ?? null,
+      // ISO TTL; null for static env refs, which never expire.
+      expiresAt: r.expiresAt ? new Date(r.expiresAt).toISOString() : null,
     })),
   })
 })

--- a/src/preview/getConfiguredRefs.ts
+++ b/src/preview/getConfiguredRefs.ts
@@ -2,7 +2,9 @@ import type { Env } from '../config'
 import {
   parseConfiguredPreviewRefs,
   parseConfiguredPreviewRefsSafe,
+  parseSingleRef,
   type ConfiguredPreviewRef,
+  type ParsedPreviewRef,
 } from './parseConfiguredPreviewRefs'
 import { REFS_INDEX_KEY } from '../cache/r2Cache'
 
@@ -21,7 +23,7 @@ type RefEntry = { expiresAt: number; publishedAt?: string; prUrl?: string }
 /** canonical `commit.<sha>` -> RefEntry. */
 type RefIndex = Record<string, RefEntry>
 
-function canonical(ref: ConfiguredPreviewRef): string {
+function canonical(ref: ParsedPreviewRef): string {
   return `${ref.type}.${ref.ref}`
 }
 
@@ -74,15 +76,23 @@ export async function getConfiguredRefs(
 ): Promise<ConfiguredPreviewRef[]> {
   const fromEnv = parseConfiguredPreviewRefsSafe(env.VITE_PLUS_PREVIEW_REFS)
 
-  let fromR2: ConfiguredPreviewRef[] = []
+  const fromR2: ConfiguredPreviewRef[] = []
   try {
     const { index } = await readRefIndex(env)
     const now = Date.now()
-    const live = Object.keys(index).filter((c) => index[c].expiresAt > now)
-    fromR2 = parseConfiguredPreviewRefsSafe(live.join(',')).map((r) => {
-      const entry = index[`${r.type}.${r.ref}`]
-      return { ...r, publishedAt: entry?.publishedAt, prUrl: entry?.prUrl }
-    })
+    // Each index entry is already in hand here, so attach its runtime state
+    // directly instead of re-deriving the key and looking it back up.
+    for (const [key, entry] of Object.entries(index)) {
+      if (entry.expiresAt <= now) continue
+      const parsed = parseSingleRef(key)
+      if (!parsed) continue
+      fromR2.push({
+        ...parsed,
+        publishedAt: entry.publishedAt,
+        prUrl: entry.prUrl,
+        expiresAt: entry.expiresAt,
+      })
+    }
   } catch (err) {
     console.warn('Failed to read preview refs from R2:', err)
   }
@@ -97,7 +107,7 @@ export async function registerRef(
   env: Env,
   ref: string,
   extra?: { publishedAt?: string; prUrl?: string },
-): Promise<ConfiguredPreviewRef> {
+): Promise<ParsedPreviewRef> {
   const [parsed] = parseConfiguredPreviewRefs(ref)
   await mutateRefIndex(env, (index) => {
     const existing = index[canonical(parsed)]

--- a/src/preview/parseConfiguredPreviewRefs.ts
+++ b/src/preview/parseConfiguredPreviewRefs.ts
@@ -10,17 +10,22 @@
  */
 import { commitVersion } from './parsePreviewVersion'
 
-export type ConfiguredPreviewRef = {
+/** A ref as produced by parsing alone, with no runtime state. */
+export type ParsedPreviewRef = {
   type: 'commit'
   ref: string
   version: string
-  /** Populated by getConfiguredRefs from the runtime refs index, when known. */
+}
+
+/** A parsed ref enriched by getConfiguredRefs with runtime refs-index state. */
+export type ConfiguredPreviewRef = ParsedPreviewRef & {
   publishedAt?: string
   prUrl?: string
+  expiresAt?: number
 }
 
 /** Parse one trimmed ref token, or return null if it is not a commit ref. */
-function parseSingleRef(value: string): ConfiguredPreviewRef | null {
+export function parseSingleRef(value: string): ParsedPreviewRef | null {
   const commit = value.match(/^commit\.([0-9a-f]{7,40})$/i)
   if (!commit) return null
   return {
@@ -41,7 +46,7 @@ function splitRefs(input: string | undefined): string[] {
 /** Strict parser: throws on an invalid or non-commit ref. */
 export function parseConfiguredPreviewRefs(
   input: string | undefined,
-): ConfiguredPreviewRef[] {
+): ParsedPreviewRef[] {
   return splitRefs(input).map((value) => {
     const ref = parseSingleRef(value)
     if (!ref) {
@@ -56,9 +61,9 @@ export function parseConfiguredPreviewRefs(
 /** Lenient variant: drops invalid refs instead of throwing. */
 export function parseConfiguredPreviewRefsSafe(
   input: string | undefined,
-): ConfiguredPreviewRef[] {
+): ParsedPreviewRef[] {
   // Skip invalid config entries rather than failing the whole packument.
   return splitRefs(input)
     .map(parseSingleRef)
-    .filter((r): r is ConfiguredPreviewRef => r !== null)
+    .filter((r): r is ParsedPreviewRef => r !== null)
 }

--- a/test/worker.test.ts
+++ b/test/worker.test.ts
@@ -517,6 +517,7 @@ describe('admin: refs', () => {
         version: string
         publishedAt: string | null
         prUrl: string | null
+        expiresAt: string | null
       }>
     }
     const entry = body.refs.find((r) => r.ref === `commit.${sha}`)
@@ -526,6 +527,11 @@ describe('admin: refs', () => {
     expect(typeof entry!.publishedAt).toBe('string')
     expect(Number.isNaN(Date.parse(entry!.publishedAt!))).toBe(false)
     expect(entry!.prUrl).toBe(prUrl)
+    // expiresAt is an ISO TTL in the future (90 days out).
+    expect(typeof entry!.expiresAt).toBe('string')
+    expect(Date.parse(entry!.expiresAt!)).toBeGreaterThan(
+      Date.parse(entry!.publishedAt!),
+    )
     // the old dist-tag field is gone.
     expect(entry).not.toHaveProperty('tag')
   })
@@ -553,12 +559,18 @@ describe('admin: refs', () => {
 
     const res = await SELF.fetch(`${BASE}/-/refs`)
     const body = (await res.json()) as {
-      refs: Array<{ ref: string; publishedAt: string | null; prUrl: string | null }>
+      refs: Array<{
+        ref: string
+        publishedAt: string | null
+        prUrl: string | null
+        expiresAt: string | null
+      }>
     }
     const entry = body.refs.find((r) => r.ref === `commit.${sha}`)
     expect(entry).toBeTruthy()
     expect(typeof entry!.publishedAt).toBe('string')
     expect(entry!.prUrl).toBeNull()
+    expect(typeof entry!.expiresAt).toBe('string')
   })
 
   it('registers a ref and injects it into the packument', async () => {


### PR DESCRIPTION
Follow-up to #22: a `/simplify` cleanup pass plus the `expiresAt` field you asked about.

## Changes

- **`expiresAt` on `/-/refs`**: each ref now reports its index TTL as an ISO timestamp. `null` for static env refs (which never expire); set (~90 days out) for refs registered via publish.
- **Single-pass ref resolution** (`getConfiguredRefs`): resolves runtime refs in one loop over the index, with each entry already in hand. Drops the `join`/re-split round-trip, the extra `.map()`, the per-ref spread-over-relookup, and the inline key re-derivation that duplicated the existing `canonical()` helper, all on the packument hot path.
- **Honest parse type**: split `ParsedPreviewRef` (pure parse result, what the parser can produce) from `ConfiguredPreviewRef` (enriched with refs-index state: `publishedAt`/`prUrl`/`expiresAt`). The parser's return type no longer carries fields it can never set.

## /simplify review outcome

Four cleanup agents reviewed #22's diff. Applied: the hot-path single-pass rewrite and the type split. Skipped as justified: the `registerRef` merge (load-bearing, no extra I/O), `?? null` in the API (keeps fields stable/present), `publishedAt` living in both the per-package meta and the per-ref index (two granularities; deriving `/-/refs` from meta would cost an R2 get per ref), and the `dist-tags` init (still normalizes packument shape).

`tsc` clean, 59 tests pass.