### PR TITLE
Inject a mutable pr-<n> dist-tag for PR-published refs

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,12 @@ runtime via the admin endpoint below (stored in a single R2 index object read
 with a cheap `get`, not a rate-limited KV `list`), with no redeploy. Both
 sources are merged.
 
+For refs published from a PR (the action forwards the PR url), the served
+packument also exposes a `pr-<n>` dist-tag pointing at that PR's
+latest-published commit version. The per-commit versions stay immutable; the tag
+moves as the PR advances, so `npm/pnpm install <pkg>@pr-<n>` against this
+registry installs the PR's head build.
+
 ## Admin endpoints
 
 Writes are guarded by `Authorization: Bearer <ADMIN_TOKEN>` (set `ADMIN_TOKEN`

--- a/src/app.ts
+++ b/src/app.ts
@@ -39,12 +39,6 @@ import {
  */
 const UNPUBLISHED_PREVIEW_TIME = '2020-01-01T00:00:00.000Z'
 
-/** Extract the PR number from a GitHub pull-request url, or null. */
-function prNumberFromUrl(url: string | undefined): string | null {
-  const m = url?.match(/\/pull\/(\d+)/)
-  return m ? m[1] : null
-}
-
 type HonoEnv = { Bindings: Env }
 
 export const app = new Hono<HonoEnv>()
@@ -361,16 +355,15 @@ app.get('*', async (c) => {
   // Mutable `pr-<n>` dist-tags: point each PR at its latest-published commit
   // version, so `vite-plus@pr-<n>` installs the PR's head build. The per-commit
   // versions stay immutable; only the tag moves as the PR advances.
-  const latestByPr = new Map<string, { version: string; t: number }>()
+  const latestPrTime = new Map<string, number>()
   for (const ref of refs) {
-    const prNum = prNumberFromUrl(ref.prUrl)
-    if (!prNum || !packument.versions[ref.version]) continue
+    if (!ref.prNumber || !packument.versions[ref.version]) continue
     const t = ref.publishedAt ? Date.parse(ref.publishedAt) : 0
-    const cur = latestByPr.get(prNum)
-    if (!cur || t >= cur.t) latestByPr.set(prNum, { version: ref.version, t })
-  }
-  for (const [prNum, { version }] of latestByPr) {
-    packument['dist-tags'][`pr-${prNum}`] = version
+    const prev = latestPrTime.get(ref.prNumber)
+    if (prev === undefined || t >= prev) {
+      latestPrTime.set(ref.prNumber, t)
+      packument['dist-tags'][`pr-${ref.prNumber}`] = ref.version
+    }
   }
 
   return new Response(JSON.stringify(packument), {

--- a/src/app.ts
+++ b/src/app.ts
@@ -39,6 +39,12 @@ import {
  */
 const UNPUBLISHED_PREVIEW_TIME = '2020-01-01T00:00:00.000Z'
 
+/** Extract the PR number from a GitHub pull-request url, or null. */
+function prNumberFromUrl(url: string | undefined): string | null {
+  const m = url?.match(/\/pull\/(\d+)/)
+  return m ? m[1] : null
+}
+
 type HonoEnv = { Bindings: Env }
 
 export const app = new Hono<HonoEnv>()
@@ -351,6 +357,21 @@ app.get('*', async (c) => {
       }
     }),
   )
+
+  // Mutable `pr-<n>` dist-tags: point each PR at its latest-published commit
+  // version, so `vite-plus@pr-<n>` installs the PR's head build. The per-commit
+  // versions stay immutable; only the tag moves as the PR advances.
+  const latestByPr = new Map<string, { version: string; t: number }>()
+  for (const ref of refs) {
+    const prNum = prNumberFromUrl(ref.prUrl)
+    if (!prNum || !packument.versions[ref.version]) continue
+    const t = ref.publishedAt ? Date.parse(ref.publishedAt) : 0
+    const cur = latestByPr.get(prNum)
+    if (!cur || t >= cur.t) latestByPr.set(prNum, { version: ref.version, t })
+  }
+  for (const [prNum, { version }] of latestByPr) {
+    packument['dist-tags'][`pr-${prNum}`] = version
+  }
 
   return new Response(JSON.stringify(packument), {
     headers: {

--- a/src/preview/getConfiguredRefs.ts
+++ b/src/preview/getConfiguredRefs.ts
@@ -3,6 +3,7 @@ import {
   parseConfiguredPreviewRefs,
   parseConfiguredPreviewRefsSafe,
   parseSingleRef,
+  prNumberFromUrl,
   type ConfiguredPreviewRef,
   type ParsedPreviewRef,
 } from './parseConfiguredPreviewRefs'
@@ -90,6 +91,7 @@ export async function getConfiguredRefs(
         ...parsed,
         publishedAt: entry.publishedAt,
         prUrl: entry.prUrl,
+        prNumber: prNumberFromUrl(entry.prUrl),
         expiresAt: entry.expiresAt,
       })
     }

--- a/src/preview/parseConfiguredPreviewRefs.ts
+++ b/src/preview/parseConfiguredPreviewRefs.ts
@@ -21,7 +21,15 @@ export type ParsedPreviewRef = {
 export type ConfiguredPreviewRef = ParsedPreviewRef & {
   publishedAt?: string
   prUrl?: string
+  /** PR number projected from prUrl, when published from a PR. */
+  prNumber?: string
   expiresAt?: number
+}
+
+/** Extract the PR number from a GitHub pull-request url, or undefined. */
+export function prNumberFromUrl(url: string | undefined): string | undefined {
+  const m = url?.match(/\/pull\/(\d+)/)
+  return m ? m[1] : undefined
 }
 
 /** Parse one trimmed ref token, or return null if it is not a commit ref. */

--- a/test/unit.test.ts
+++ b/test/unit.test.ts
@@ -6,6 +6,7 @@ import {
 import {
   parseConfiguredPreviewRefs,
   parseConfiguredPreviewRefsSafe,
+  prNumberFromUrl,
 } from '../src/preview/parseConfiguredPreviewRefs'
 import { toPkgPrNewUrl } from '../src/preview/toPkgPrNewUrl'
 import {
@@ -97,6 +98,22 @@ describe('parseConfiguredPreviewRefs', () => {
         version: '0.0.0-commit.abcdef0',
       },
     ])
+  })
+})
+
+describe('prNumberFromUrl', () => {
+  it('extracts the PR number from a GitHub PR url', () => {
+    expect(
+      prNumberFromUrl('https://github.com/voidzero-dev/vite-plus/pull/1569'),
+    ).toBe('1569')
+    // trailing path segments (e.g. /files) are tolerated.
+    expect(prNumberFromUrl('https://github.com/o/r/pull/42/files')).toBe('42')
+  })
+
+  it('returns undefined for non-PR or missing urls', () => {
+    expect(prNumberFromUrl(undefined)).toBeUndefined()
+    expect(prNumberFromUrl('')).toBeUndefined()
+    expect(prNumberFromUrl('https://github.com/o/r/commit/abc123')).toBeUndefined()
   })
 })
 

--- a/test/worker.test.ts
+++ b/test/worker.test.ts
@@ -573,6 +573,44 @@ describe('admin: refs', () => {
     expect(typeof entry!.expiresAt).toBe('string')
   })
 
+  it('injects a mutable pr-<n> dist-tag pointing at the PR latest commit', async () => {
+    const prUrl = 'https://github.com/voidzero-dev/vite-plus/pull/777'
+    const publish = (sha: string, version: string) =>
+      SELF.fetch(`${BASE}/-/publish`, {
+        method: 'POST',
+        headers: { ...AUTH, 'content-type': 'application/json' },
+        body: JSON.stringify({
+          ref: `commit.${sha}`,
+          prUrl,
+          packages: [
+            {
+              name: 'vite-plus',
+              version,
+              packageJson: { name: 'vite-plus', version },
+              integrity: 'sha512-test',
+              shasum: '',
+            },
+          ],
+        }),
+      })
+    const verA = '0.0.0-commit.aaa7770'
+    const verB = '0.0.0-commit.bbb7770'
+    expect((await publish('aaa7770', verA)).status).toBe(201)
+    // A read between publishes keeps B's server-stamp strictly later than A's.
+    await SELF.fetch(`${BASE}/-/refs`)
+    expect((await publish('bbb7770', verB)).status).toBe(201)
+
+    const pack = await SELF.fetch(`${BASE}/vite-plus`, {
+      headers: { accept: 'application/json' },
+    })
+    const body = (await pack.json()) as Record<string, any>
+    // both immutable commit versions are present...
+    expect(body.versions[verA]).toBeTruthy()
+    expect(body.versions[verB]).toBeTruthy()
+    // ...and the PR tag points at the latest-published one (B).
+    expect(body['dist-tags']['pr-777']).toBe(verB)
+  })
+
   it('registers a ref and injects it into the packument', async () => {
     const add = await SELF.fetch(`${BASE}/-/refs`, {
       method: 'POST',


### PR DESCRIPTION
Builds on the `prUrl` we now store per ref (#22) so a PR number can be used to install through the bridge.

## Change

For refs published from a PR, the served packument now exposes a `pr-<n>` dist-tag pointing at that PR's **latest-published** commit version. The per-commit versions stay immutable; only the tag moves as the PR advances, so `<pkg>@pr-<n>` against this registry installs the PR's head build.

- PR number derived from the ref's `prUrl` (`/pull/<n>`).
- Latest = highest server-stamped `publishedAt` among that PR's live refs.
- The tag is only set for versions actually present in the packument.

Unlike the removed `commit-<sha>` tag (which duplicated the version), this is a meaningful mutable pointer, the registry equivalent of "install PR n".

## Follow-up (separate, vite-plus repo)

This enables wiring `VP_PR_VERSION` in `packages/cli/install.sh` to the bridge: a numeric `VP_PR_VERSION` resolves `<pkg>@pr-<n>` from `registry-bridge.viteplus.dev` instead of building raw pkg.pr.new URLs, gaining the bridge's correct `time`/integrity. Happy to draft that PR next.

`tsc` clean, 60 tests pass (added: pr tag points at the PR's latest commit).