### PR TITLE
Add pkg.pr.new-style direct download URL

### DIFF
--- a/.github/actions/publish-preview/dist/index.mjs
+++ b/.github/actions/publish-preview/dist/index.mjs
@@ -353,6 +353,9 @@ function isWorkspacePackage(name, env) {
 function commitVersion(sha) {
   return `0.0.0-commit.${sha}`;
 }
+function shaToVersion(ref) {
+  return /^[0-9a-f]{7,40}$/i.test(ref) ? commitVersion(ref) : null;
+}
 function parsePreviewVersion(version) {
   const commit = version.match(/^0\.0\.0-commit\.([0-9a-f]{7,40})$/i);
   if (commit) return { type: "commit", ref: commit[1] };
@@ -360,10 +363,6 @@ function parsePreviewVersion(version) {
 }
 
 // src/tarball/rewritePackageJson.ts
-function refToVersion(ref) {
-  if (/^[0-9a-f]{7,40}$/i.test(ref)) return commitVersion(ref);
-  return null;
-}
 function pkgPrNewUrlToVersion(spec, env) {
   const prefix = `${env.PKG_PR_NEW_BASE}/${env.PREVIEW_OWNER}/${env.PREVIEW_REPO}/`;
   if (!spec.startsWith(prefix)) return null;
@@ -372,7 +371,7 @@ function pkgPrNewUrlToVersion(spec, env) {
   if (at <= 0) return null;
   const name = rest.slice(0, at);
   if (!isWorkspacePackage(name, env)) return null;
-  return refToVersion(rest.slice(at + 1));
+  return shaToVersion(rest.slice(at + 1));
 }
 function rewriteDependencies(deps, version, env) {
   if (!deps) return deps;

--- a/README.md
+++ b/README.md
@@ -136,6 +136,24 @@ latest-published commit version. The per-commit versions stay immutable; the tag
 moves as the PR advances, so `npm/pnpm install <pkg>@pr-<n>` against this
 registry installs the PR's head build.
 
+## Direct tarball download (pkg.pr.new-style)
+
+A pkg.pr.new-style URL resolves a ref to a tarball, handy for a `curl` download
+or a single self-contained package. Swap the hostname on any pkg.pr.new URL:
+
+```bash
+# The repo's main package (vite-plus) at a PR's latest commit, or a commit sha:
+curl -L https://registry-bridge.viteplus.dev/voidzero-dev/vite-plus@1891
+curl -L https://registry-bridge.viteplus.dev/voidzero-dev/vite-plus@<sha>
+# A specific (here scoped) package:
+curl -L https://registry-bridge.viteplus.dev/voidzero-dev/vite-plus/@voidzero-dev/vite-plus-core@1891
+```
+
+It 302-redirects to the canonical `/tarballs/<pkg>/<version>.tgz`. Note the
+bridge rewrites a preview tarball's transitive deps to versions (not pkg.pr.new
+URLs), so for a full install of the meta-package with its platform binaries, use
+the registry + `pr-<n>` tag above rather than this URL as a bare dependency.
+
 ## Admin endpoints
 
 Writes are guarded by `Authorization: Bearer <ADMIN_TOKEN>` (set `ADMIN_TOKEN`

--- a/src/app.ts
+++ b/src/app.ts
@@ -3,10 +3,14 @@ import type { ContentfulStatusCode } from 'hono/utils/http-status'
 import type { Env } from './config'
 import { HttpError } from './httpError'
 import { isWorkspacePackage } from './preview/packages'
-import { parsePreviewVersion } from './preview/parsePreviewVersion'
+import {
+  commitVersion,
+  parsePreviewVersion,
+} from './preview/parsePreviewVersion'
 import { parseConfiguredPreviewRefs } from './preview/parseConfiguredPreviewRefs'
 import {
   getConfiguredRefs,
+  latestVersionByPr,
   registerRef,
   unregisterRef,
 } from './preview/getConfiguredRefs'
@@ -38,6 +42,35 @@ import {
  * pinned preview during that gap.
  */
 const UNPUBLISHED_PREVIEW_TIME = '2020-01-01T00:00:00.000Z'
+
+/**
+ * Parse a pkg.pr.new-style direct-download path for the configured repo:
+ *   /<owner>/<repo>@<ref>        -> { pkg: <repo>, ref }
+ *   /<owner>/<repo>/<pkg>@<ref>  -> { pkg, ref }   (<pkg> may be scoped)
+ * Returns null when the path is not this form.
+ */
+function parsePkgPrNewDownload(
+  pathname: string,
+  env: Env,
+): { pkg: string; ref: string } | null {
+  const base = `/${env.PREVIEW_OWNER}/${env.PREVIEW_REPO}`
+  if (!pathname.startsWith(base)) return null
+  const rest = pathname.slice(base.length)
+  // Bare form: the repo's main package (named after the repo).
+  if (rest.startsWith('@')) {
+    const ref = rest.slice(1)
+    return ref && !ref.includes('/') ? { pkg: env.PREVIEW_REPO, ref } : null
+  }
+  // Package form: `<pkg>@<ref>`; lastIndexOf('@') keeps a scoped pkg intact.
+  if (rest.startsWith('/')) {
+    const seg = rest.slice(1)
+    const at = seg.lastIndexOf('@')
+    if (at <= 0) return null
+    const ref = seg.slice(at + 1)
+    return ref && !ref.includes('/') ? { pkg: seg.slice(0, at), ref } : null
+  }
+  return null
+}
 
 type HonoEnv = { Bindings: Env }
 
@@ -301,6 +334,35 @@ app.get('*', async (c) => {
     return await serveTarball(c.env, npmTarball.name, npmTarball.version)
   }
 
+  // pkg.pr.new-style direct download: /<owner>/<repo>[/<pkg>]@<ref>. Resolve a
+  // PR number to its latest commit version (or a commit sha to its synthetic
+  // version) and 302 to the canonical tarball. A PR number's mapping is mutable
+  // (it moves with the PR), so the redirect itself is not cached.
+  const download = parsePkgPrNewDownload(pathname, c.env)
+  if (download) {
+    if (!isWorkspacePackage(download.pkg, c.env)) {
+      throw new HttpError(404, `Unknown package: ${download.pkg}`)
+    }
+    let version: string | null = null
+    if (/^\d+$/.test(download.ref)) {
+      version =
+        latestVersionByPr(await getConfiguredRefs(c.env)).get(download.ref) ??
+        null
+    } else if (/^[0-9a-f]{7,40}$/i.test(download.ref)) {
+      version = commitVersion(download.ref)
+    }
+    if (!version) {
+      throw new HttpError(404, `No preview build for ref ${download.ref}`)
+    }
+    return new Response(null, {
+      status: 302,
+      headers: {
+        location: `${c.env.PUBLIC_BASE_URL}/tarballs/${download.pkg}/${version}.tgz`,
+        'cache-control': 'no-store',
+      },
+    })
+  }
+
   const pkgReq = parsePackagePath(pathname)
   if (!pkgReq) return redirectToNpm(c.env, c.req.raw)
 
@@ -353,17 +415,13 @@ app.get('*', async (c) => {
   )
 
   // Mutable `pr-<n>` dist-tags: point each PR at its latest-published commit
-  // version, so `vite-plus@pr-<n>` installs the PR's head build. The per-commit
-  // versions stay immutable; only the tag moves as the PR advances.
-  const latestPrTime = new Map<string, number>()
-  for (const ref of refs) {
-    if (!ref.prNumber || !packument.versions[ref.version]) continue
-    const t = ref.publishedAt ? Date.parse(ref.publishedAt) : 0
-    const prev = latestPrTime.get(ref.prNumber)
-    if (prev === undefined || t >= prev) {
-      latestPrTime.set(ref.prNumber, t)
-      packument['dist-tags'][`pr-${ref.prNumber}`] = ref.version
-    }
+  // version present in this packument, so `<pkg>@pr-<n>` installs the PR's head
+  // build. The per-commit versions stay immutable; only the tag moves.
+  for (const [prNum, version] of latestVersionByPr(
+    refs,
+    (v) => v in packument.versions,
+  )) {
+    packument['dist-tags'][`pr-${prNum}`] = version
   }
 
   return new Response(JSON.stringify(packument), {

--- a/src/app.ts
+++ b/src/app.ts
@@ -4,8 +4,8 @@ import type { Env } from './config'
 import { HttpError } from './httpError'
 import { isWorkspacePackage } from './preview/packages'
 import {
-  commitVersion,
   parsePreviewVersion,
+  shaToVersion,
 } from './preview/parsePreviewVersion'
 import { parseConfiguredPreviewRefs } from './preview/parseConfiguredPreviewRefs'
 import {
@@ -17,6 +17,7 @@ import {
 import {
   parseNpmTarballPath,
   parsePackagePath,
+  parsePkgPrNewDownload,
   parseTarballPath,
   parseUploadPath,
 } from './registry/parsePackageName'
@@ -28,7 +29,7 @@ import {
   getPreviewTarballBody,
 } from './tarball/getPreviewBuild'
 import type { PreviewMeta } from './tarball/buildPreviewTarball'
-import { metaKey, tarballKey } from './cache/r2Cache'
+import { metaKey, tarballKey, tarballUrl } from './cache/r2Cache'
 import { requireAdmin } from './security/auth'
 import {
   packumentCacheControl,
@@ -42,35 +43,6 @@ import {
  * pinned preview during that gap.
  */
 const UNPUBLISHED_PREVIEW_TIME = '2020-01-01T00:00:00.000Z'
-
-/**
- * Parse a pkg.pr.new-style direct-download path for the configured repo:
- *   /<owner>/<repo>@<ref>        -> { pkg: <repo>, ref }
- *   /<owner>/<repo>/<pkg>@<ref>  -> { pkg, ref }   (<pkg> may be scoped)
- * Returns null when the path is not this form.
- */
-function parsePkgPrNewDownload(
-  pathname: string,
-  env: Env,
-): { pkg: string; ref: string } | null {
-  const base = `/${env.PREVIEW_OWNER}/${env.PREVIEW_REPO}`
-  if (!pathname.startsWith(base)) return null
-  const rest = pathname.slice(base.length)
-  // Bare form: the repo's main package (named after the repo).
-  if (rest.startsWith('@')) {
-    const ref = rest.slice(1)
-    return ref && !ref.includes('/') ? { pkg: env.PREVIEW_REPO, ref } : null
-  }
-  // Package form: `<pkg>@<ref>`; lastIndexOf('@') keeps a scoped pkg intact.
-  if (rest.startsWith('/')) {
-    const seg = rest.slice(1)
-    const at = seg.lastIndexOf('@')
-    if (at <= 0) return null
-    const ref = seg.slice(at + 1)
-    return ref && !ref.includes('/') ? { pkg: seg.slice(0, at), ref } : null
-  }
-  return null
-}
 
 type HonoEnv = { Bindings: Env }
 
@@ -123,6 +95,34 @@ async function serveTarball(
       'content-type': 'application/gzip',
       'cache-control': tarballCacheControl(),
       'content-length': String(result.contentLength),
+    },
+  })
+}
+
+/**
+ * Resolve a pkg.pr.new-style download (a PR number -> its latest commit
+ * version, or a commit sha -> its synthetic version) and 302 to the canonical
+ * tarball. A PR number's mapping is mutable (it moves with the PR), so this
+ * redirect is not cached; the immutable tarball it points at is.
+ */
+async function serveDownloadRedirect(
+  env: Env,
+  download: { pkg: string; ref: string },
+): Promise<Response> {
+  if (!isWorkspacePackage(download.pkg, env)) {
+    throw new HttpError(404, `Unknown package: ${download.pkg}`)
+  }
+  const version = /^\d+$/.test(download.ref)
+    ? (latestVersionByPr(await getConfiguredRefs(env)).get(download.ref) ?? null)
+    : shaToVersion(download.ref)
+  if (!version) {
+    throw new HttpError(404, `No preview build for ref ${download.ref}`)
+  }
+  return new Response(null, {
+    status: 302,
+    headers: {
+      location: tarballUrl(env, download.pkg, version),
+      'cache-control': 'no-store',
     },
   })
 }
@@ -302,9 +302,7 @@ app.post('/-/purge', async (c) => {
   await Promise.all([
     c.env.STORAGE.delete(tarballKey(name, version)),
     c.env.STORAGE.delete(metaKey(name, version)),
-    caches.default.delete(
-      new Request(`${c.env.PUBLIC_BASE_URL}/tarballs/${name}/${version}.tgz`),
-    ),
+    caches.default.delete(new Request(tarballUrl(c.env, name, version))),
   ])
   return c.json({ purged: { package: name, version } })
 })
@@ -334,34 +332,15 @@ app.get('*', async (c) => {
     return await serveTarball(c.env, npmTarball.name, npmTarball.version)
   }
 
-  // pkg.pr.new-style direct download: /<owner>/<repo>[/<pkg>]@<ref>. Resolve a
-  // PR number to its latest commit version (or a commit sha to its synthetic
-  // version) and 302 to the canonical tarball. A PR number's mapping is mutable
-  // (it moves with the PR), so the redirect itself is not cached.
-  const download = parsePkgPrNewDownload(pathname, c.env)
-  if (download) {
-    if (!isWorkspacePackage(download.pkg, c.env)) {
-      throw new HttpError(404, `Unknown package: ${download.pkg}`)
-    }
-    let version: string | null = null
-    if (/^\d+$/.test(download.ref)) {
-      version =
-        latestVersionByPr(await getConfiguredRefs(c.env)).get(download.ref) ??
-        null
-    } else if (/^[0-9a-f]{7,40}$/i.test(download.ref)) {
-      version = commitVersion(download.ref)
-    }
-    if (!version) {
-      throw new HttpError(404, `No preview build for ref ${download.ref}`)
-    }
-    return new Response(null, {
-      status: 302,
-      headers: {
-        location: `${c.env.PUBLIC_BASE_URL}/tarballs/${download.pkg}/${version}.tgz`,
-        'cache-control': 'no-store',
-      },
-    })
-  }
+  // pkg.pr.new-style direct download: /<owner>/<repo>[/<pkg>]@<ref> -> 302 to
+  // the canonical tarball. Discriminated here (ahead of the packument parse)
+  // because the URL shape overlaps the scoped-packument namespace.
+  const download = parsePkgPrNewDownload(
+    pathname,
+    c.env.PREVIEW_OWNER,
+    c.env.PREVIEW_REPO,
+  )
+  if (download) return await serveDownloadRedirect(c.env, download)
 
   const pkgReq = parsePackagePath(pathname)
   if (!pkgReq) return redirectToNpm(c.env, c.req.raw)

--- a/src/cache/r2Cache.ts
+++ b/src/cache/r2Cache.ts
@@ -1,7 +1,17 @@
-/** R2 object keys for a generated preview build. */
+/** R2 object keys and the public URL for a generated preview build. */
+import type { Env } from '../config'
 
 export function tarballKey(name: string, version: string): string {
   return `tarball/${name}/${version}.tgz`
+}
+
+/** Public URL of a preview tarball (the inverse of parseTarballPath). */
+export function tarballUrl(
+  env: Pick<Env, 'PUBLIC_BASE_URL'>,
+  name: string,
+  version: string,
+): string {
+  return `${env.PUBLIC_BASE_URL}/tarballs/${name}/${version}.tgz`
 }
 
 export function metaKey(name: string, version: string): string {

--- a/src/preview/getConfiguredRefs.ts
+++ b/src/preview/getConfiguredRefs.ts
@@ -104,6 +104,30 @@ export async function getConfiguredRefs(
   return [...byVersion.values()]
 }
 
+/**
+ * Map each PR number to its latest-published commit version among `refs`
+ * (max publishedAt wins). Used for the `pr-<n>` dist-tag and the pkg.pr.new
+ * style download URL. `accept` optionally restricts eligible versions (e.g.
+ * only versions present in a built packument).
+ */
+export function latestVersionByPr(
+  refs: ConfiguredPreviewRef[],
+  accept: (version: string) => boolean = () => true,
+): Map<string, string> {
+  const out = new Map<string, string>()
+  const latestT = new Map<string, number>()
+  for (const ref of refs) {
+    if (!ref.prNumber || !accept(ref.version)) continue
+    const t = ref.publishedAt ? Date.parse(ref.publishedAt) : 0
+    const prev = latestT.get(ref.prNumber)
+    if (prev === undefined || t >= prev) {
+      latestT.set(ref.prNumber, t)
+      out.set(ref.prNumber, ref.version)
+    }
+  }
+  return out
+}
+
 /** Validate and register a ref. Concurrency-safe via the conditional put. */
 export async function registerRef(
   env: Env,

--- a/src/preview/parsePreviewVersion.ts
+++ b/src/preview/parsePreviewVersion.ts
@@ -18,6 +18,14 @@ export function commitVersion(sha: string): string {
   return `0.0.0-commit.${sha}`
 }
 
+/**
+ * A commit-sha ref (7-40 hex) -> its synthetic version, else null. Non-sha refs
+ * (e.g. a PR number) are mutable and intentionally not routed here.
+ */
+export function shaToVersion(ref: string): string | null {
+  return /^[0-9a-f]{7,40}$/i.test(ref) ? commitVersion(ref) : null
+}
+
 export function parsePreviewVersion(version: string): PreviewRef | null {
   const commit = version.match(/^0\.0\.0-commit\.([0-9a-f]{7,40})$/i)
   if (commit) return { type: 'commit', ref: commit[1] }

--- a/src/registry/buildVersionMetadata.ts
+++ b/src/registry/buildVersionMetadata.ts
@@ -1,5 +1,6 @@
 import type { Env } from '../config'
 import type { PreviewMeta } from '../tarball/buildPreviewTarball'
+import { tarballUrl } from '../cache/r2Cache'
 
 /**
  * Fields from a package.json that should not appear in a registry version
@@ -48,7 +49,7 @@ export function buildVersionMetadata(
   meta._id = `${packageName}@${version}`
 
   const dist: Record<string, any> = {
-    tarball: `${env.PUBLIC_BASE_URL}/tarballs/${packageName}/${version}.tgz`,
+    tarball: tarballUrl(env, packageName, version),
   }
   if (preview.shasum) dist.shasum = preview.shasum
   if (preview.integrity) dist.integrity = preview.integrity

--- a/src/registry/parsePackageName.ts
+++ b/src/registry/parsePackageName.ts
@@ -130,6 +130,40 @@ export function parseNpmTarballPath(pathname: string): TarballRequest | null {
   return { name, version }
 }
 
+/**
+ * Parse a pkg.pr.new-style direct-download path for the configured repo:
+ *   /<owner>/<repo>@<ref>        -> { pkg: <repo>, ref }   (repo's main package)
+ *   /<owner>/<repo>/<pkg>@<ref>  -> { pkg, ref }           (<pkg> may be scoped)
+ * Returns null when the path is not this form.
+ */
+export function parsePkgPrNewDownload(
+  pathname: string,
+  owner: string,
+  repo: string,
+): { pkg: string; ref: string } | null {
+  const decoded = decodePath(pathname)
+  const base = `${owner}/${repo}`
+  if (!decoded || !decoded.startsWith(base)) return null
+  const rest = decoded.slice(base.length)
+
+  let pkg: string
+  let ref: string
+  if (rest.startsWith('@')) {
+    pkg = repo
+    ref = rest.slice(1)
+  } else if (rest.startsWith('/')) {
+    // `<pkg>@<ref>`; lastIndexOf('@') keeps a scoped pkg name intact.
+    const seg = rest.slice(1)
+    const at = seg.lastIndexOf('@')
+    if (at <= 0) return null
+    pkg = seg.slice(0, at)
+    ref = seg.slice(at + 1)
+  } else {
+    return null
+  }
+  return ref && !ref.includes('/') ? { pkg, ref } : null
+}
+
 /** Encode a package name for an outbound npm registry URL. */
 export function encodeNpmPackageName(name: string): string {
   return name.startsWith('@') ? name.replace('/', '%2F') : name

--- a/src/tarball/rewritePackageJson.ts
+++ b/src/tarball/rewritePackageJson.ts
@@ -1,5 +1,5 @@
 import { isWorkspacePackage, PREVIEW_PACKAGES } from '../preview/packages'
-import { commitVersion } from '../preview/parsePreviewVersion'
+import { shaToVersion } from '../preview/parsePreviewVersion'
 
 /** Config needed to rebuild pkg.pr.new URLs as bridge URLs. */
 export interface RewriteEnv {
@@ -8,13 +8,6 @@ export interface RewriteEnv {
   PREVIEW_OWNER: string
   PREVIEW_REPO: string
   WORKSPACE_PACKAGES: string
-}
-
-function refToVersion(ref: string): string | null {
-  // Only immutable commit refs are routed through the bridge. A PR-number URL
-  // (a mutable ref) is left as the original direct pkg.pr.new URL.
-  if (/^[0-9a-f]{7,40}$/i.test(ref)) return commitVersion(ref)
-  return null
 }
 
 /**
@@ -37,9 +30,10 @@ export function pkgPrNewUrlToVersion(
   if (at <= 0) return null
   const name = rest.slice(0, at)
   // Only route packages the bridge will serve; otherwise leave the working
-  // direct pkg.pr.new URL in place.
+  // direct pkg.pr.new URL in place. A non-commit (e.g. PR-number) ref is mutable
+  // and likewise left as the original direct URL (shaToVersion returns null).
   if (!isWorkspacePackage(name, env)) return null
-  return refToVersion(rest.slice(at + 1))
+  return shaToVersion(rest.slice(at + 1))
 }
 
 /**

--- a/test/worker.test.ts
+++ b/test/worker.test.ts
@@ -466,6 +466,74 @@ describe('integrity', () => {
 
 const AUTH = { authorization: 'Bearer test-admin-token' }
 
+describe('pkg.pr.new-style download', () => {
+  it('redirects /<owner>/<repo>@<sha> to the version tarball', async () => {
+    const sha = 'abc1234'
+    const res = await SELF.fetch(`${BASE}/voidzero-dev/vite-plus@${sha}`, {
+      redirect: 'manual',
+    })
+    expect(res.status).toBe(302)
+    expect(res.headers.get('location')).toBe(
+      `${BASE}/tarballs/vite-plus/0.0.0-commit.${sha}.tgz`,
+    )
+    // The PR->version mapping is mutable, so the redirect is not cached.
+    expect(res.headers.get('cache-control')).toBe('no-store')
+  })
+
+  it('redirects /<owner>/<repo>/<scoped-pkg>@<sha> to that package', async () => {
+    const sha = 'def5678'
+    const res = await SELF.fetch(
+      `${BASE}/voidzero-dev/vite-plus/@voidzero-dev/vite-plus-core@${sha}`,
+      { redirect: 'manual' },
+    )
+    expect(res.status).toBe(302)
+    expect(res.headers.get('location')).toBe(
+      `${BASE}/tarballs/@voidzero-dev/vite-plus-core/0.0.0-commit.${sha}.tgz`,
+    )
+  })
+
+  it('redirects /<owner>/<repo>@<pr> to the PR latest commit tarball', async () => {
+    const prUrl = 'https://github.com/voidzero-dev/vite-plus/pull/909'
+    const publish = (sha: string, version: string) =>
+      SELF.fetch(`${BASE}/-/publish`, {
+        method: 'POST',
+        headers: { ...AUTH, 'content-type': 'application/json' },
+        body: JSON.stringify({
+          ref: `commit.${sha}`,
+          prUrl,
+          packages: [
+            {
+              name: 'vite-plus',
+              version,
+              packageJson: { name: 'vite-plus', version },
+              integrity: 'sha512-test',
+              shasum: '',
+            },
+          ],
+        }),
+      })
+    const verB = '0.0.0-commit.ddd9090'
+    expect((await publish('ccc9090', '0.0.0-commit.ccc9090')).status).toBe(201)
+    await SELF.fetch(`${BASE}/-/refs`) // keep B's server-stamp strictly later
+    expect((await publish('ddd9090', verB)).status).toBe(201)
+
+    const res = await SELF.fetch(`${BASE}/voidzero-dev/vite-plus@909`, {
+      redirect: 'manual',
+    })
+    expect(res.status).toBe(302)
+    expect(res.headers.get('location')).toBe(
+      `${BASE}/tarballs/vite-plus/${verB}.tgz`,
+    )
+  })
+
+  it('404s for a PR with no published build', async () => {
+    const res = await SELF.fetch(`${BASE}/voidzero-dev/vite-plus@999999`, {
+      redirect: 'manual',
+    })
+    expect(res.status).toBe(404)
+  })
+})
+
 describe('admin: refs', () => {
   it('writes require auth (reads do not)', async () => {
     // POST/DELETE require the bearer token.


### PR DESCRIPTION
Builds on #24. Adds a pkg.pr.new-style URL so developers can fetch a build's tgz directly.

## Endpoint

- `GET /<owner>/<repo>@<ref>` → the repo's main package (`vite-plus`).
- `GET /<owner>/<repo>/<pkg>@<ref>` → that package (`<pkg>` may be scoped).
- `<ref>` is a PR number (→ that PR's latest commit version, via #24's resolver) or a commit sha (→ `0.0.0-commit.<sha>`).
- **302-redirects** to the canonical `/tarballs/<pkg>/<version>.tgz` (which serves from R2 or redirects unbuilt binaries to pkg.pr.new). Mirrors pkg.pr.new, so existing pkg.pr.new URLs work by swapping only the hostname.

```bash
curl -L https://registry-bridge.viteplus.dev/voidzero-dev/vite-plus@1891
curl -L https://registry-bridge.viteplus.dev/voidzero-dev/vite-plus/@voidzero-dev/vite-plus-core@<sha>
```

## Refactor

The PR-number → latest-commit-version logic is now a shared `latestVersionByPr()` in the refs layer, reused by both the `pr-<n>` dist-tag and this endpoint (the second caller that justified extracting it, per the #24 `/simplify` altitude note).

## Caveat (documented)

The bridge rewrites a preview tarball's transitive deps to versions, not self-contained pkg.pr.new URLs. So this URL is for direct downloads / single self-contained packages; a full `vite-plus` install with its platform binaries should use the registry + `pr-<n>` tag, not this URL as a bare dependency.

`tsc` clean, 66 tests pass (added 4: sha, scoped pkg, PR→latest, unknown-PR 404).