### PR TITLE
Cache the npm time map; drop the O(N) time-map copy

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -15,14 +15,16 @@ import {
   unregisterRef,
 } from './preview/getConfiguredRefs'
 import {
-  encodeNpmPackageName,
   parseNpmTarballPath,
   parsePackagePath,
   parsePkgPrNewDownload,
   parseTarballPath,
   parseUploadPath,
 } from './registry/parsePackageName'
-import { fetchNpmPackument, fetchNpmTime } from './registry/fetchNpmPackument'
+import {
+  fetchNpmPackument,
+  getNpmTimeCached,
+} from './registry/fetchNpmPackument'
 import { buildVersionMetadata } from './registry/buildVersionMetadata'
 import { redirectToNpm } from './registry/redirectToNpm'
 import {
@@ -44,44 +46,6 @@ import {
  * pinned preview during that gap.
  */
 const UNPUBLISHED_PREVIEW_TIME = '2020-01-01T00:00:00.000Z'
-
-/**
- * npm's per-version `time` map, cached per-colo so the FULL packument (an order
- * of magnitude larger than the abbreviated one, e.g. ~1.4 MB for vite-plus) is
- * fetched and parsed rarely instead of on every request, the dominant hot-path
- * allocation. Past versions' times are immutable; the short TTL only bounds how
- * long a brand-new npm version's time lags, and such a version is younger than
- * any minimum-release-age threshold (so a momentarily-absent entry is filtered
- * out, not an ERR_PNPM_MISSING_TIME). Refs/versions stay fresh (read live), so
- * this adds no publish-visibility lag.
- */
-async function getNpmTimeCached(
-  env: Env,
-  name: string,
-  ctx: { waitUntil(promise: Promise<unknown>): void },
-): Promise<Record<string, string> | null> {
-  const key = new Request(
-    `${env.PUBLIC_BASE_URL}/-/npm-time/${encodeNpmPackageName(name)}`,
-  )
-  const hit = await caches.default.match(key)
-  if (hit) return (await hit.json()) as Record<string, string>
-
-  // Cache the small EXTRACTED map (not the multi-MB body); `{}` for a 404 so a
-  // not-on-npm package isn't re-fetched in full every request.
-  const time = await fetchNpmTime(env, name)
-  ctx.waitUntil(
-    caches.default.put(
-      key,
-      new Response(JSON.stringify(time ?? {}), {
-        headers: {
-          'content-type': 'application/json',
-          'cache-control': packumentCacheControl(),
-        },
-      }),
-    ),
-  )
-  return time
-}
 
 type HonoEnv = { Bindings: Env }
 
@@ -409,7 +373,7 @@ app.get('*', async (c) => {
   // each injected preview version's entry is its server-stamped publish time
   // (UNPUBLISHED_PREVIEW_TIME until published), added in the loop below. `npmTime`
   // is a fresh per-request object (cache parse or fetch), so mutate it in place.
-  const time: Record<string, string> = npmTime ?? {}
+  const time: Record<string, string> = npmTime
   packument.time = time
 
   // Inject each configured ref. The R2 meta reads are independent, so run them

--- a/src/app.ts
+++ b/src/app.ts
@@ -15,6 +15,7 @@ import {
   unregisterRef,
 } from './preview/getConfiguredRefs'
 import {
+  encodeNpmPackageName,
   parseNpmTarballPath,
   parsePackagePath,
   parsePkgPrNewDownload,
@@ -43,6 +44,44 @@ import {
  * pinned preview during that gap.
  */
 const UNPUBLISHED_PREVIEW_TIME = '2020-01-01T00:00:00.000Z'
+
+/**
+ * npm's per-version `time` map, cached per-colo so the FULL packument (an order
+ * of magnitude larger than the abbreviated one, e.g. ~1.4 MB for vite-plus) is
+ * fetched and parsed rarely instead of on every request, the dominant hot-path
+ * allocation. Past versions' times are immutable; the short TTL only bounds how
+ * long a brand-new npm version's time lags, and such a version is younger than
+ * any minimum-release-age threshold (so a momentarily-absent entry is filtered
+ * out, not an ERR_PNPM_MISSING_TIME). Refs/versions stay fresh (read live), so
+ * this adds no publish-visibility lag.
+ */
+async function getNpmTimeCached(
+  env: Env,
+  name: string,
+  ctx: { waitUntil(promise: Promise<unknown>): void },
+): Promise<Record<string, string> | null> {
+  const key = new Request(
+    `${env.PUBLIC_BASE_URL}/-/npm-time/${encodeNpmPackageName(name)}`,
+  )
+  const hit = await caches.default.match(key)
+  if (hit) return (await hit.json()) as Record<string, string>
+
+  // Cache the small EXTRACTED map (not the multi-MB body); `{}` for a 404 so a
+  // not-on-npm package isn't re-fetched in full every request.
+  const time = await fetchNpmTime(env, name)
+  ctx.waitUntil(
+    caches.default.put(
+      key,
+      new Response(JSON.stringify(time ?? {}), {
+        headers: {
+          'content-type': 'application/json',
+          'cache-control': packumentCacheControl(),
+        },
+      }),
+    ),
+  )
+  return time
+}
 
 type HonoEnv = { Bindings: Env }
 
@@ -354,7 +393,7 @@ app.get('*', async (c) => {
   // response keeps the compact abbreviated version docs.
   const [base, npmTime, refs] = await Promise.all([
     fetchNpmPackument(c.env, name),
-    fetchNpmTime(c.env, name),
+    getNpmTimeCached(c.env, name, c.executionCtx),
     getConfiguredRefs(c.env),
   ])
 
@@ -368,8 +407,9 @@ app.get('*', async (c) => {
   // pnpm's time-based resolution (`minimum-release-age`) hard-errors without a
   // `time` map (ERR_PNPM_MISSING_TIME). Seed it from npm's real publish times;
   // each injected preview version's entry is its server-stamped publish time
-  // (UNPUBLISHED_PREVIEW_TIME until published), added in the loop below.
-  const time: Record<string, string> = { ...(npmTime ?? {}) }
+  // (UNPUBLISHED_PREVIEW_TIME until published), added in the loop below. `npmTime`
+  // is a fresh per-request object (cache parse or fetch), so mutate it in place.
+  const time: Record<string, string> = npmTime ?? {}
   packument.time = time
 
   // Inject each configured ref. The R2 meta reads are independent, so run them

--- a/src/cache/headers.ts
+++ b/src/cache/headers.ts
@@ -16,3 +16,12 @@ export function tarballCacheControl(): string {
 export function packumentCacheControl(): string {
   return SHORT_MAX_AGE
 }
+
+/**
+ * Cache policy for the cached npm `time` map. Short for its OWN reason, bounding
+ * how long a brand-new npm version's time lags, which is independent of the
+ * packument TTL even though they currently share a value.
+ */
+export function npmTimeCacheControl(): string {
+  return SHORT_MAX_AGE
+}

--- a/src/registry/fetchNpmPackument.ts
+++ b/src/registry/fetchNpmPackument.ts
@@ -1,6 +1,7 @@
 import type { Env } from '../config'
 import { encodeNpmPackageName } from './parsePackageName'
 import { HttpError } from '../httpError'
+import { npmTimeCacheControl } from '../cache/headers'
 
 // Abbreviated packument format. Always request this from npm: it is an order
 // of magnitude smaller than the full packument (which some clients' Accept
@@ -64,7 +65,7 @@ export async function fetchNpmPackument(
  * null. Kept separate from fetchNpmPackument so the served response carries the
  * compact abbreviated version docs while still preserving npm's real times.
  */
-export async function fetchNpmTime(
+async function fetchNpmTime(
   env: Env,
   name: string,
 ): Promise<Record<string, string> | null> {
@@ -78,4 +79,44 @@ export async function fetchNpmTime(
   return time && typeof time === 'object'
     ? (time as Record<string, string>)
     : null
+}
+
+/**
+ * npm's per-version `time` map, cached per-colo so the FULL packument (an order
+ * of magnitude larger than the abbreviated one, e.g. ~1.4 MB for vite-plus) is
+ * fetched and parsed rarely instead of on every request, the dominant hot-path
+ * allocation. Past versions' times are immutable; the short TTL only bounds how
+ * long a brand-new npm version's time lags, and such a version is younger than
+ * any minimum-release-age threshold (so a momentarily-absent entry is filtered
+ * out, not an ERR_PNPM_MISSING_TIME). Refs/versions stay fresh (read live), so
+ * this adds no publish-visibility lag.
+ */
+export async function getNpmTimeCached(
+  env: Env,
+  name: string,
+  // Structural so this stays decoupled from Hono's vs Cloudflare's
+  // `ExecutionContext` types (which differ); both have `waitUntil`.
+  ctx: { waitUntil(promise: Promise<unknown>): void },
+): Promise<Record<string, string>> {
+  const key = new Request(
+    `${env.PUBLIC_BASE_URL}/-/npm-time/${encodeNpmPackageName(name)}`,
+  )
+  const hit = await caches.default.match(key)
+  if (hit) return (await hit.json()) as Record<string, string>
+
+  // Store the small EXTRACTED map (not the multi-MB body); `{}` for a 404 so a
+  // not-on-npm package isn't re-fetched in full every request.
+  const time = (await fetchNpmTime(env, name)) ?? {}
+  ctx.waitUntil(
+    caches.default.put(
+      key,
+      new Response(JSON.stringify(time), {
+        headers: {
+          'content-type': 'application/json',
+          'cache-control': npmTimeCacheControl(),
+        },
+      }),
+    ),
+  )
+  return time
 }

--- a/test/worker.test.ts
+++ b/test/worker.test.ts
@@ -162,6 +162,26 @@ describe('packument endpoint', () => {
     expect(body.time['0.0.0-commit.a832a55']).toBeTruthy()
   })
 
+  it('serves npm time consistently across repeated requests (time-map cache)', async () => {
+    // npm's `time` map is cached per-colo so the full packument isn't reparsed
+    // every request; repeated requests must still serve the correct npm times,
+    // and the per-request preview-time injection must not corrupt the cached map.
+    const timeOf = async () =>
+      (
+        (await (
+          await SELF.fetch(`${BASE}/vite-plus`, {
+            headers: { accept: 'application/json' },
+          })
+        ).json()) as Record<string, any>
+      ).time as Record<string, string>
+    const a = await timeOf()
+    const b = await timeOf()
+    expect(a['0.2.1']).toBe('2026-06-18T05:33:32.399Z')
+    expect(b['0.2.1']).toBe('2026-06-18T05:33:32.399Z')
+    // the preview time is still injected on every request (not lost to caching).
+    expect(b['0.0.0-commit.a832a55']).toBeTruthy()
+  })
+
   it('stamps the preview release date server-side at publish, stable across requests', async () => {
     // The release date is stamped server-side once at publish, not npm's
     // package-modified time, not a per-request clock, and not a client value.


### PR DESCRIPTION
First PR from the CF Workers performance/memory review. Targets the packument hot path (128 MB / isolate, CPU + subrequest caps).

## Changes

- **Cache the npm `time` map** (`getNpmTimeCached`). The handler fetched the **full** npm packument on every request just to extract the per-version `time` map, and the full packument is an order of magnitude larger than the abbreviated one (~**1.4 MB** for vite-plus → ~6-9 MB transient parse, the dominant hot-path allocation, growing ~10.6 KB/version). Now the extracted map (~6.8 KB) is cached per-colo in `caches.default` with a short TTL, so the big fetch+parse runs rarely instead of per request.
- **Drop the `{ ...(npmTime ?? {}) }` O(N) spread** , `npmTime` is a fresh per-request object, so seed `time` by reference and mutate in place.

## Why this shape (and not a whole-packument cache)

Caching the **assembled packument** would be a bigger win but `caches.default.delete` only purges the **local colo**, so a publish would lag up to 300s in other colos, a real regression for the publish-then-install workflow. The time-map cache avoids that: refs and versions are still read live, so publishes appear immediately. A brand-new npm version's `time` can lag by the TTL, but such a version is younger than any `minimum-release-age` threshold (filtered out), so there's no `ERR_PNPM_MISSING_TIME` risk.

## Review notes

- P5 from the review verified: npm sends `vary: accept-encoding, accept`, so the abbreviated and full fetches don't collide in CF's subrequest cache.
- 67 tests pass (added: npm `time` stays correct across repeated requests and isn't corrupted by the per-request preview-time injection).

## Follow-ups (separate PRs, your call)

- **P1 (highest severity):** the packument does `3 + K` subrequests (one R2 `get` per ref); at high K this approaches the CF subrequest cap. Fix: aggregate per-package version docs so it's a constant read. Structural, needs care around the publish CAS.
- **P0:** whole-packument edge cache (the bigger win, but with the cross-colo publish-lag trade-off above).
- **P4:** `fetchUpstreamTarball` 2× double-copy (64 MB ceiling, gated to the on-demand fallback for two small packages).