### PR TITLE
Fix packument 500: getNpmTimeCached must not require an ExecutionContext

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -357,7 +357,7 @@ app.get('*', async (c) => {
   // response keeps the compact abbreviated version docs.
   const [base, npmTime, refs] = await Promise.all([
     fetchNpmPackument(c.env, name),
-    getNpmTimeCached(c.env, name, c.executionCtx),
+    getNpmTimeCached(c.env, name),
     getConfiguredRefs(c.env),
   ])
 

--- a/src/registry/fetchNpmPackument.ts
+++ b/src/registry/fetchNpmPackument.ts
@@ -103,7 +103,8 @@ export async function getNpmTimeCached(
   try {
     const hit = await caches.default.match(key)
     if (hit) return (await hit.json()) as Record<string, string>
-  } catch {
+  } catch (err) {
+    console.warn(`npm-time cache read failed for ${name}:`, err)
     return (await fetchNpmTime(env, name)) ?? {}
   }
 
@@ -122,8 +123,9 @@ export async function getNpmTimeCached(
         },
       }),
     )
-  } catch {
-    // best-effort cache population
+  } catch (err) {
+    // Best-effort cache population; log so a failing runtime is visible.
+    console.warn(`npm-time cache write failed for ${name}:`, err)
   }
   return time
 }

--- a/src/registry/fetchNpmPackument.ts
+++ b/src/registry/fetchNpmPackument.ts
@@ -94,21 +94,26 @@ async function fetchNpmTime(
 export async function getNpmTimeCached(
   env: Env,
   name: string,
-  // Structural so this stays decoupled from Hono's vs Cloudflare's
-  // `ExecutionContext` types (which differ); both have `waitUntil`.
-  ctx: { waitUntil(promise: Promise<unknown>): void },
 ): Promise<Record<string, string>> {
   const key = new Request(
     `${env.PUBLIC_BASE_URL}/-/npm-time/${encodeNpmPackageName(name)}`,
   )
-  const hit = await caches.default.match(key)
-  if (hit) return (await hit.json()) as Record<string, string>
+  // The Cache API isn't guaranteed on every runtime this deploys to; degrade to
+  // a direct fetch on any cache error rather than failing the request.
+  try {
+    const hit = await caches.default.match(key)
+    if (hit) return (await hit.json()) as Record<string, string>
+  } catch {
+    return (await fetchNpmTime(env, name)) ?? {}
+  }
 
   // Store the small EXTRACTED map (not the multi-MB body); `{}` for a 404 so a
   // not-on-npm package isn't re-fetched in full every request.
   const time = (await fetchNpmTime(env, name)) ?? {}
-  ctx.waitUntil(
-    caches.default.put(
+  try {
+    // Awaited (not waitUntil) so it works without an ExecutionContext, which the
+    // managed runtime does not always provide; the write is fast and miss-only.
+    await caches.default.put(
       key,
       new Response(JSON.stringify(time), {
         headers: {
@@ -116,7 +121,9 @@ export async function getNpmTimeCached(
           'cache-control': npmTimeCacheControl(),
         },
       }),
-    ),
-  )
+    )
+  } catch {
+    // best-effort cache population
+  }
   return time
 }


### PR DESCRIPTION
**Live regression from #26.** Every workspace-package packument (vite-plus, core) is returning **500** in production; non-workspace packages (e.g. react) still 302 correctly.

## Cause

#26 passed `c.executionCtx` into `getNpmTimeCached` to defer the cache `put` via `waitUntil`. The managed (void) runtime does not provide an `ExecutionContext`, and Hono's `c.executionCtx` getter **throws** when one is absent, so the handler threw before building the packument. `pool-workers` does provide an `ExecutionContext`, which is why the tests passed.

## Fix

`getNpmTimeCached` no longer takes a `ctx`:
- **`await`s the cache `put`** (fast, miss-only) instead of `waitUntil`, so it needs no `ExecutionContext`.
- **Wraps the Cache API in try/catch**, so any runtime without a working `caches.default` degrades to a direct `fetchNpmTime` (the pre-#26 behavior) instead of failing the request.

So the worst case is now "no caching" (= pre-#26), never a 500.

`tsc` clean, 67 tests pass, action bundle unaffected. I'll verify live once it deploys.