### PR TITLE
CI: deploy + smoke-test staging on PR, production on main

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,19 +27,8 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
-      # Staging first, then smoke-test the REAL runtime. This catches
-      # platform-only failures the pool-workers tests can't (e.g. the void
-      # Cache API ban that 500'd every packument). If the smoke step fails, the
-      # job stops here and production is never deployed.
-      - name: Deploy to staging
-        run: pnpm exec void deploy --project pkg-pr-registry-bridge-staging
-        env:
-          VOID_TOKEN: ${{ secrets.VOID_TOKEN }}
-
-      - name: Smoke-test staging
-        run: node scripts/smoke-test.mjs https://pkg-pr-registry-bridge-staging.void.app
-
-      # Only reached when the staging smoke test passed.
+      # Staging is validated on the PR (see staging.yml), so main just ships to
+      # production and re-runs the smoke test against the live prod runtime.
       - name: Deploy to production
         run: pnpm exec void deploy
         env:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,9 +27,26 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
-      # VOID_PROJECT is required because the project link in `.void/` is
-      # gitignored, so there is nothing to resolve from in CI.
-      - run: pnpm exec void deploy
+      # Staging first, then smoke-test the REAL runtime. This catches
+      # platform-only failures the pool-workers tests can't (e.g. the void
+      # Cache API ban that 500'd every packument). If the smoke step fails, the
+      # job stops here and production is never deployed.
+      - name: Deploy to staging
+        run: pnpm exec void deploy --project pkg-pr-registry-bridge-staging
         env:
           VOID_TOKEN: ${{ secrets.VOID_TOKEN }}
+
+      - name: Smoke-test staging
+        run: node scripts/smoke-test.mjs https://pkg-pr-registry-bridge-staging.void.app
+
+      # Only reached when the staging smoke test passed.
+      - name: Deploy to production
+        run: pnpm exec void deploy
+        env:
+          VOID_TOKEN: ${{ secrets.VOID_TOKEN }}
+          # VOID_PROJECT is required because the project link in `.void/` is
+          # gitignored, so there is nothing to resolve from in CI.
           VOID_PROJECT: pkg-pr-registry-bridge
+
+      - name: Smoke-test production
+        run: node scripts/smoke-test.mjs https://registry-bridge.viteplus.dev

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,8 +27,19 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
-      # Staging is validated on the PR (see staging.yml), so main just ships to
-      # production and re-runs the smoke test against the live prod runtime.
+      # Staging-first gate, even though PRs already smoke-test staging
+      # (staging.yml), a change can still reach main without that check: a fork
+      # PR can't read VOID_TOKEN, and direct pushes skip PR CI. So re-run the
+      # staging deploy + smoke here and only ship to production when it passes.
+      - name: Deploy to staging
+        run: pnpm exec void deploy --project pkg-pr-registry-bridge-staging
+        env:
+          VOID_TOKEN: ${{ secrets.VOID_TOKEN }}
+
+      - name: Smoke-test staging
+        run: node scripts/smoke-test.mjs https://pkg-pr-registry-bridge-staging.void.app
+
+      # Only reached when the staging smoke test passed.
       - name: Deploy to production
         run: pnpm exec void deploy
         env:

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -1,0 +1,43 @@
+name: Staging
+on:
+  pull_request:
+    branches: [main]
+
+# One shared staging environment, so serialize across PRs: queue rather than
+# clobber another PR's deploy+smoke, and never cancel a run mid-flight.
+concurrency:
+  group: void-staging
+  cancel-in-progress: false
+
+jobs:
+  staging:
+    runs-on: ubuntu-latest
+    # Fork PRs can't read VOID_TOKEN; they still get ci.yml (typecheck + test).
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    steps:
+      # Actions are pinned to a full commit SHA (org policy); kept in sync with ci.yml.
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+        with:
+          version: 11.9.0
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      # Deploy this PR's code to the shared staging project, then smoke-test the
+      # REAL Void runtime. This catches platform-only failures the pool-workers
+      # unit tests can't (e.g. the Void Cache API ban that 500'd every packument)
+      # BEFORE the change reaches main. Make this a required status check so a
+      # failing smoke test blocks the merge.
+      - name: Deploy to staging
+        run: pnpm exec void deploy --project pkg-pr-registry-bridge-staging
+        env:
+          VOID_TOKEN: ${{ secrets.VOID_TOKEN }}
+
+      - name: Smoke-test staging
+        run: node scripts/smoke-test.mjs https://pkg-pr-registry-bridge-staging.void.app

--- a/README.md
+++ b/README.md
@@ -264,14 +264,18 @@ The public origin (`PUBLIC_BASE_URL` in `.env.production`) is the custom domain
 underlying Void platform URL `pkg-pr-registry-bridge.void.app` keeps working
 too).
 
-Pushes to `main` auto-deploy via `.github/workflows/deploy.yml`. It deploys to a
-**staging** project first (`pkg-pr-registry-bridge-staging.void.app`), runs
-`scripts/smoke-test.mjs` against that live URL, and only then deploys to
-production (and smoke-tests it). The smoke test exercises the real Void runtime
-(`/_health`, the `/vite-plus` packument, `/-/refs`, a download redirect), which
-catches platform-only failures the `pool-workers` unit tests cannot, e.g. the
-Void platform forbidding `caches.default`, which 500'd every packument while all
-unit tests passed. A failed staging smoke test stops the job before production.
+CI deploys in two stages:
+
+- **Every PR** (`.github/workflows/staging.yml`) deploys the change to a
+  **staging** project (`pkg-pr-registry-bridge-staging.void.app`) and runs
+  `scripts/smoke-test.mjs` against that live URL. The smoke test exercises the
+  real Void runtime (`/_health`, the `/vite-plus` packument, `/-/refs`, a
+  download redirect), catching platform-only failures the `pool-workers` unit
+  tests cannot, e.g. the Void platform forbidding `caches.default`, which 500'd
+  every packument while all unit tests passed. Make `Staging` a required status
+  check (branch protection) so a failing smoke test blocks the merge.
+- **Push to `main`** (`.github/workflows/deploy.yml`) deploys to production and
+  smoke-tests the live prod runtime.
 
 Add a `VOID_TOKEN` repository secret (`void auth token` copies one to your
 clipboard); the same token deploys both projects. Run the smoke test locally

--- a/README.md
+++ b/README.md
@@ -264,6 +264,15 @@ The public origin (`PUBLIC_BASE_URL` in `.env.production`) is the custom domain
 underlying Void platform URL `pkg-pr-registry-bridge.void.app` keeps working
 too).
 
-Pushes to `main` auto-deploy via `.github/workflows/deploy.yml` (`pnpm exec void
-deploy`). Add a `VOID_TOKEN` repository secret (`void auth token` copies one to
-your clipboard); `VOID_PROJECT` is pinned in the workflow.
+Pushes to `main` auto-deploy via `.github/workflows/deploy.yml`. It deploys to a
+**staging** project first (`pkg-pr-registry-bridge-staging.void.app`), runs
+`scripts/smoke-test.mjs` against that live URL, and only then deploys to
+production (and smoke-tests it). The smoke test exercises the real Void runtime
+(`/_health`, the `/vite-plus` packument, `/-/refs`, a download redirect), which
+catches platform-only failures the `pool-workers` unit tests cannot, e.g. the
+Void platform forbidding `caches.default`, which 500'd every packument while all
+unit tests passed. A failed staging smoke test stops the job before production.
+
+Add a `VOID_TOKEN` repository secret (`void auth token` copies one to your
+clipboard); the same token deploys both projects. Run the smoke test locally
+with `pnpm smoke <url>`, and deploy staging by hand with `pnpm deploy:staging`.

--- a/README.md
+++ b/README.md
@@ -264,18 +264,22 @@ The public origin (`PUBLIC_BASE_URL` in `.env.production`) is the custom domain
 underlying Void platform URL `pkg-pr-registry-bridge.void.app` keeps working
 too).
 
-CI deploys in two stages:
+CI deploys in two stages, both smoke-testing the REAL Void runtime, which the
+`pool-workers` unit tests can't emulate (e.g. the platform forbidding
+`caches.default`, which 500'd every packument while all unit tests passed):
 
-- **Every PR** (`.github/workflows/staging.yml`) deploys the change to a
-  **staging** project (`pkg-pr-registry-bridge-staging.void.app`) and runs
-  `scripts/smoke-test.mjs` against that live URL. The smoke test exercises the
-  real Void runtime (`/_health`, the `/vite-plus` packument, `/-/refs`, a
-  download redirect), catching platform-only failures the `pool-workers` unit
-  tests cannot, e.g. the Void platform forbidding `caches.default`, which 500'd
-  every packument while all unit tests passed. Make `Staging` a required status
-  check (branch protection) so a failing smoke test blocks the merge.
-- **Push to `main`** (`.github/workflows/deploy.yml`) deploys to production and
-  smoke-tests the live prod runtime.
+- **Every PR** (`.github/workflows/staging.yml`) deploys the change to the
+  shared **staging** project (`pkg-pr-registry-bridge-staging.void.app`) and
+  runs `scripts/smoke-test.mjs` against it. Make `Staging` a required status
+  check (branch protection) so a failing smoke test blocks the merge. (Skipped
+  for fork PRs, which can't read `VOID_TOKEN`.)
+- **Push to `main`** (`.github/workflows/deploy.yml`) re-runs the staging deploy
+  + smoke as a gate, then deploys to production and smoke-tests it. The gate is
+  necessary because a change can reach `main` without the PR check, a fork PR or
+  a direct push, so production never ships unless staging passes first.
+
+The smoke test hits `/_health`, the `/vite-plus` packument (200 with `time`),
+`/-/refs`, and a download redirect.
 
 Add a `VOID_TOKEN` repository secret (`void auth token` copies one to your
 clipboard); the same token deploys both projects. Run the smoke test locally

--- a/package.json
+++ b/package.json
@@ -11,6 +11,8 @@
     "deploy": "void deploy && node scripts/warm.mjs && node scripts/e2e-bun.mjs",
     "deploy:only": "void deploy",
     "warm": "node scripts/warm.mjs",
+    "smoke": "node scripts/smoke-test.mjs",
+    "deploy:staging": "void deploy --project pkg-pr-registry-bridge-staging",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/scripts/smoke-test.mjs
+++ b/scripts/smoke-test.mjs
@@ -1,0 +1,103 @@
+// Smoke-test a deployed bridge against its REAL runtime. This catches
+// platform-only failures that the vitest pool-workers runtime cannot emulate,
+// e.g. the void platform forbidding `caches.default` (which 500'd every
+// packument in production while all unit tests passed). Run it against staging
+// before promoting to production.
+//
+//   node scripts/smoke-test.mjs https://pkg-pr-registry-bridge-staging.void.app
+
+const base = (process.argv[2] || '').replace(/\/+$/, '')
+if (!base) {
+  console.error('usage: node scripts/smoke-test.mjs <base-url>')
+  process.exit(2)
+}
+
+// A configured commit ref (also a valid sha for the download endpoint).
+const SHA = '6acea1aa818e96365b5811d47360367ba18a3a05'
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms))
+
+function assert(cond, msg) {
+  if (!cond) throw new Error(msg)
+}
+
+const checks = [
+  {
+    name: 'GET /_health -> 200 {status:"ok"}',
+    async run() {
+      const res = await fetch(`${base}/_health`)
+      assert(res.status === 200, `status ${res.status}`)
+      const body = await res.json()
+      assert(body?.status === 'ok', `body ${JSON.stringify(body)}`)
+    },
+  },
+  {
+    name: 'GET /vite-plus -> 200 with versions + time',
+    async run() {
+      const res = await fetch(`${base}/vite-plus`, {
+        headers: { accept: 'application/json' },
+      })
+      assert(res.status === 200, `status ${res.status}`)
+      const body = await res.json()
+      assert(
+        body?.versions && Object.keys(body.versions).length > 0,
+        'no versions',
+      )
+      // The `time` map is what 500'd under the void Cache API ban, so it is the
+      // load-bearing assertion: the packument handler must complete and emit it.
+      assert(body?.time && Object.keys(body.time).length > 0, 'no time map')
+    },
+  },
+  {
+    name: 'GET /-/refs -> 200 with refs[]',
+    async run() {
+      const res = await fetch(`${base}/-/refs`)
+      assert(res.status === 200, `status ${res.status}`)
+      const body = await res.json()
+      assert(Array.isArray(body?.refs), 'refs is not an array')
+    },
+  },
+  {
+    name: 'GET /<owner>/<repo>@<sha> -> 302 to a tarball',
+    async run() {
+      const res = await fetch(`${base}/voidzero-dev/vite-plus@${SHA}`, {
+        redirect: 'manual',
+      })
+      assert(res.status === 302, `status ${res.status}`)
+      assert(res.headers.get('location'), 'no location header')
+    },
+  },
+]
+
+console.log(`smoke-testing ${base}`)
+
+// Wait for the new deployment to go live (edge propagation) before asserting.
+async function waitForLive() {
+  for (let i = 0; i < 10; i++) {
+    try {
+      await checks[0].run()
+      return
+    } catch {
+      await sleep(3000)
+    }
+  }
+  // One more, surfacing the real error.
+  await checks[0].run()
+}
+await waitForLive()
+
+let failed = 0
+for (const check of checks) {
+  try {
+    await check.run()
+    console.log(`  ✓ ${check.name}`)
+  } catch (err) {
+    failed++
+    console.error(`  ✗ ${check.name}: ${err.message}`)
+  }
+}
+
+if (failed > 0) {
+  console.error(`\n${failed} smoke check(s) failed against ${base}`)
+  process.exit(1)
+}
+console.log(`\nall ${checks.length} smoke checks passed against ${base}`)


### PR DESCRIPTION
Prevents the class of outage we just hit: the packument 500 (Void forbidding `caches.default`) reached production because the `pool-workers` test runtime can't emulate the deployed platform. CI now proves the real runtime works **on staging at PR time**, before merge.

## Pipeline

- **`staging.yml` (pull_request)** , deploys the PR's code to `pkg-pr-registry-bridge-staging.void.app` and runs `scripts/smoke-test.mjs` against it. One shared staging env, serialized across PRs via a single concurrency group (queue, don't clobber); fork PRs are skipped (no `VOID_TOKEN`). **Make `Staging` a required status check** so a failing smoke test blocks the merge.
- **`deploy.yml` (push to main)** , deploys to production and smoke-tests the live prod runtime.

## Smoke test (`scripts/smoke-test.mjs <url>`)

Hits the runtime-sensitive paths and asserts status + shape:
- `GET /_health` → 200 `{status:"ok"}`
- `GET /vite-plus` → 200 with `versions` **and** `time` (the `time` map is exactly what `caches.default` 500'd, the load-bearing check)
- `GET /-/refs` → 200 with `refs[]`
- `GET /voidzero-dev/vite-plus@<sha>` → 302 with a location

It would have **failed** on #26 (500 on `/vite-plus`) and **passes** on current code (verified against staging and production).

## Already set up

- Created the `pkg-pr-registry-bridge-staging` void project (R2 auto-provisioned; `ADMIN_TOKEN` is `.optional()` so staging boots with no secrets).
- `pnpm smoke <url>` and `pnpm deploy:staging` helpers; same `VOID_TOKEN` deploys both projects.
- This PR's own CI is the first live run of `staging.yml`.

Follow-up (manual, admin): mark `Staging` a required status check in branch protection. Note: staging inherits the committed env (its `PUBLIC_BASE_URL` is the prod origin, cosmetic; smoke checks don't depend on it).