### PR TITLE
Add HEAD to the download URL, returning the commit key

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,10 +149,22 @@ curl -L https://registry-bridge.viteplus.dev/voidzero-dev/vite-plus@<sha>
 curl -L https://registry-bridge.viteplus.dev/voidzero-dev/vite-plus/@voidzero-dev/vite-plus-core@1891
 ```
 
-It 302-redirects to the canonical `/tarballs/<pkg>/<version>.tgz`. Note the
-bridge rewrites a preview tarball's transitive deps to versions (not pkg.pr.new
-URLs), so for a full install of the meta-package with its platform binaries, use
-the registry + `pr-<n>` tag above rather than this URL as a bare dependency.
+A `GET` 302-redirects to the canonical `/tarballs/<pkg>/<version>.tgz`. A `HEAD`
+answers `200` (no body) and resolves the ref to its exact commit via
+pkg.pr.new-style headers, so a tool can pin a (mutable) PR number to a commit
+without downloading:
+
+```bash
+curl -I https://registry-bridge.viteplus.dev/voidzero-dev/vite-plus@1891
+# HTTP/2 200
+# x-commit-key: voidzero-dev:vite-plus:<sha>
+# x-pkg-name-key: vite-plus
+```
+
+Both `GET` and `HEAD` carry `x-commit-key`/`x-pkg-name-key`. Note the bridge
+rewrites a preview tarball's transitive deps to versions (not pkg.pr.new URLs),
+so for a full install of the meta-package with its platform binaries, use the
+registry + `pr-<n>` tag above rather than this URL as a bare dependency.
 
 ## Admin endpoints
 

--- a/scripts/smoke-test.mjs
+++ b/scripts/smoke-test.mjs
@@ -1,10 +1,13 @@
 // Smoke-test a deployed bridge against its REAL runtime. This catches
-// platform-only failures that the vitest pool-workers runtime cannot emulate,
-// e.g. the void platform forbidding `caches.default` (which 500'd every
-// packument in production while all unit tests passed). Run it against staging
-// before promoting to production.
+// platform-only failures the vitest pool-workers runtime cannot emulate, e.g.
+// the void platform forbidding `caches.default` (which 500'd every packument
+// while all unit tests passed). Run it against staging before promoting to
+// production.
 //
 //   node scripts/smoke-test.mjs https://pkg-pr-registry-bridge-staging.void.app
+//
+// Each check prints the actual response (status + key fields/headers) BEFORE
+// asserting, so a failure is debuggable straight from the CI log.
 
 const base = (process.argv[2] || '').replace(/\/+$/, '')
 if (!base) {
@@ -15,6 +18,7 @@ if (!base) {
 // A configured commit ref (also a valid sha for the download endpoint).
 const SHA = '6acea1aa818e96365b5811d47360367ba18a3a05'
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms))
+const truncate = (s, n = 300) => (s.length > n ? `${s.slice(0, n)}…` : s)
 
 function assert(cond, msg) {
   if (!cond) throw new Error(msg)
@@ -22,48 +26,75 @@ function assert(cond, msg) {
 
 const checks = [
   {
-    name: 'GET /_health -> 200 {status:"ok"}',
+    name: 'GET /_health',
     async run() {
       const res = await fetch(`${base}/_health`)
+      const body = await res.text()
+      console.log(`    ${res.status} ${truncate(body)}`)
       assert(res.status === 200, `status ${res.status}`)
-      const body = await res.json()
-      assert(body?.status === 'ok', `body ${JSON.stringify(body)}`)
+      assert(JSON.parse(body)?.status === 'ok', 'status != "ok"')
     },
   },
   {
-    name: 'GET /vite-plus -> 200 with versions + time',
+    name: 'GET /vite-plus',
     async run() {
       const res = await fetch(`${base}/vite-plus`, {
         headers: { accept: 'application/json' },
       })
-      assert(res.status === 200, `status ${res.status}`)
-      const body = await res.json()
-      assert(
-        body?.versions && Object.keys(body.versions).length > 0,
-        'no versions',
+      const body = await res.text()
+      const parsed = JSON.parse(body || 'null')
+      const nv = parsed?.versions ? Object.keys(parsed.versions).length : 0
+      const nt = parsed?.time ? Object.keys(parsed.time).length : 0
+      // The body is large on success, so summarize; print it on failure.
+      console.log(
+        `    ${res.status} versions=${nv} time=${nt}` +
+          (res.status === 200 ? '' : ` ${truncate(body)}`),
       )
+      assert(res.status === 200, `status ${res.status}`)
+      assert(nv > 0, 'no versions')
       // The `time` map is what 500'd under the void Cache API ban, so it is the
       // load-bearing assertion: the packument handler must complete and emit it.
-      assert(body?.time && Object.keys(body.time).length > 0, 'no time map')
+      assert(nt > 0, 'no time map')
     },
   },
   {
-    name: 'GET /-/refs -> 200 with refs[]',
+    name: 'GET /-/refs',
     async run() {
       const res = await fetch(`${base}/-/refs`)
+      const body = await res.text()
+      const parsed = JSON.parse(body || 'null')
+      const nr = Array.isArray(parsed?.refs) ? parsed.refs.length : 'n/a'
+      console.log(
+        `    ${res.status} refs=${nr}` +
+          (res.status === 200 ? '' : ` ${truncate(body)}`),
+      )
       assert(res.status === 200, `status ${res.status}`)
-      const body = await res.json()
-      assert(Array.isArray(body?.refs), 'refs is not an array')
+      assert(Array.isArray(parsed?.refs), 'refs is not an array')
     },
   },
   {
-    name: 'GET /<owner>/<repo>@<sha> -> 302 to a tarball',
+    name: 'GET /<owner>/<repo>@<sha> (302 to tarball)',
     async run() {
       const res = await fetch(`${base}/voidzero-dev/vite-plus@${SHA}`, {
         redirect: 'manual',
       })
+      console.log(`    ${res.status} location=${res.headers.get('location')}`)
       assert(res.status === 302, `status ${res.status}`)
       assert(res.headers.get('location'), 'no location header')
+    },
+  },
+  {
+    name: 'HEAD /<owner>/<repo>@<sha> (commit key)',
+    async run() {
+      const res = await fetch(`${base}/voidzero-dev/vite-plus@${SHA}`, {
+        method: 'HEAD',
+      })
+      const key = res.headers.get('x-commit-key')
+      console.log(
+        `    ${res.status} x-commit-key=${key} x-pkg-name-key=${res.headers.get('x-pkg-name-key')}`,
+      )
+      assert(res.status === 200, `status ${res.status}`)
+      assert(key === `voidzero-dev:vite-plus:${SHA}`, `x-commit-key=${key}`)
     },
   },
 ]
@@ -71,19 +102,15 @@ const checks = [
 console.log(`smoke-testing ${base}`)
 
 // Wait for the new deployment to go live (edge propagation) before asserting.
-async function waitForLive() {
-  for (let i = 0; i < 10; i++) {
-    try {
-      await checks[0].run()
-      return
-    } catch {
-      await sleep(3000)
-    }
+for (let i = 0; i < 10; i++) {
+  try {
+    const res = await fetch(`${base}/_health`)
+    if (res.status === 200) break
+  } catch {
+    // not up yet
   }
-  // One more, surfacing the real error.
-  await checks[0].run()
+  await sleep(3000)
 }
-await waitForLive()
 
 let failed = 0
 for (const check of checks) {
@@ -91,8 +118,8 @@ for (const check of checks) {
     await check.run()
     console.log(`  ✓ ${check.name}`)
   } catch (err) {
-    failed++
     console.error(`  ✗ ${check.name}: ${err.message}`)
+    failed++
   }
 }
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -104,13 +104,17 @@ async function serveTarball(
 
 /**
  * Resolve a pkg.pr.new-style download (a PR number -> its latest commit
- * version, or a commit sha -> its synthetic version) and 302 to the canonical
- * tarball. A PR number's mapping is mutable (it moves with the PR), so this
- * redirect is not cached; the immutable tarball it points at is.
+ * version, or a commit sha -> its synthetic version). A GET 302s to the
+ * canonical tarball; a HEAD answers 200 with no body, so a client can map a
+ * (possibly mutable) PR/sha to its exact commit without downloading. Both carry
+ * pkg.pr.new-style `x-commit-key` (`<owner>:<repo>:<sha>`) and `x-pkg-name-key`.
+ * The PR mapping is mutable, so the response is not cached; the immutable
+ * tarball it points at is.
  */
 async function serveDownloadRedirect(
   env: Env,
   download: { pkg: string; ref: string },
+  head: boolean,
 ): Promise<Response> {
   if (!isWorkspacePackage(download.pkg, env)) {
     throw new HttpError(404, `Unknown package: ${download.pkg}`)
@@ -121,12 +125,21 @@ async function serveDownloadRedirect(
   if (!version) {
     throw new HttpError(404, `No preview build for ref ${download.ref}`)
   }
+  const sha = parsePreviewVersion(version)?.ref ?? ''
+  const headers: Record<string, string> = {
+    'x-commit-key': `${env.PREVIEW_OWNER}:${env.PREVIEW_REPO}:${sha}`,
+    'x-pkg-name-key': download.pkg,
+    'cache-control': 'no-store',
+  }
+  if (head) {
+    return new Response(null, {
+      status: 200,
+      headers: { ...headers, 'content-type': 'application/tar+gzip' },
+    })
+  }
   return new Response(null, {
     status: 302,
-    headers: {
-      location: tarballUrl(env, download.pkg, version),
-      'cache-control': 'no-store',
-    },
+    headers: { ...headers, location: tarballUrl(env, download.pkg, version) },
   })
 }
 
@@ -343,7 +356,9 @@ app.get('*', async (c) => {
     c.env.PREVIEW_OWNER,
     c.env.PREVIEW_REPO,
   )
-  if (download) return await serveDownloadRedirect(c.env, download)
+  if (download) {
+    return await serveDownloadRedirect(c.env, download, c.req.method === 'HEAD')
+  }
 
   const pkgReq = parsePackagePath(pathname)
   if (!pkgReq) return redirectToNpm(c.env, c.req.raw)

--- a/test/worker.test.ts
+++ b/test/worker.test.ts
@@ -498,6 +498,9 @@ describe('pkg.pr.new-style download', () => {
     )
     // The PR->version mapping is mutable, so the redirect is not cached.
     expect(res.headers.get('cache-control')).toBe('no-store')
+    // pkg.pr.new-style commit key is on the redirect too.
+    expect(res.headers.get('x-commit-key')).toBe(`voidzero-dev:vite-plus:${sha}`)
+    expect(res.headers.get('x-pkg-name-key')).toBe('vite-plus')
   })
 
   it('redirects /<owner>/<repo>/<scoped-pkg>@<sha> to that package', async () => {
@@ -551,6 +554,48 @@ describe('pkg.pr.new-style download', () => {
       redirect: 'manual',
     })
     expect(res.status).toBe(404)
+  })
+
+  it('HEAD <owner>/<repo>@<sha> -> 200 with the commit key, no redirect', async () => {
+    const sha = 'f0f0f0f'
+    const res = await SELF.fetch(`${BASE}/voidzero-dev/vite-plus@${sha}`, {
+      method: 'HEAD',
+    })
+    expect(res.status).toBe(200)
+    expect(res.headers.get('x-commit-key')).toBe(`voidzero-dev:vite-plus:${sha}`)
+    expect(res.headers.get('x-pkg-name-key')).toBe('vite-plus')
+    // HEAD resolves the commit; it does not redirect to the tarball.
+    expect(res.headers.get('location')).toBeNull()
+  })
+
+  it('HEAD <owner>/<repo>@<pr> -> 200 with the PR latest commit key', async () => {
+    const prUrl = 'https://github.com/voidzero-dev/vite-plus/pull/808'
+    const sha = 'e1e1e10'
+    const version = `0.0.0-commit.${sha}`
+    const pub = await SELF.fetch(`${BASE}/-/publish`, {
+      method: 'POST',
+      headers: { ...AUTH, 'content-type': 'application/json' },
+      body: JSON.stringify({
+        ref: `commit.${sha}`,
+        prUrl,
+        packages: [
+          {
+            name: 'vite-plus',
+            version,
+            packageJson: { name: 'vite-plus', version },
+            integrity: 'sha512-test',
+            shasum: '',
+          },
+        ],
+      }),
+    })
+    expect(pub.status).toBe(201)
+    const res = await SELF.fetch(`${BASE}/voidzero-dev/vite-plus@808`, {
+      method: 'HEAD',
+    })
+    expect(res.status).toBe(200)
+    expect(res.headers.get('x-commit-key')).toBe(`voidzero-dev:vite-plus:${sha}`)
+    expect(res.headers.get('x-pkg-name-key')).toBe('vite-plus')
   })
 })
 


### PR DESCRIPTION
Mirrors pkg.pr.new's `HEAD` behavior (`curl -I .../voidzero-dev/vite-plus@1891`) so a tool can resolve a (mutable) PR ref to its exact commit without downloading.

## Change

- **`HEAD /<owner>/<repo>[/<pkg>]@<ref>`** → `200` (no body) with:
  - `x-commit-key: <owner>:<repo>:<sha>` , the resolved commit (PR number → its latest commit; sha → itself)
  - `x-pkg-name-key: <pkg>`
- **`GET`** still 302s to the tarball, and now also carries those two headers.

## Smoke-test improvements (per your request)

- `scripts/smoke-test.mjs` now **prints each response** (status + key fields/headers) *before* asserting, so a failed check is debuggable straight from the CI log. Example failure output: `200 x-commit-key=null` then `✗ HEAD … : x-commit-key=null`.
- Added a HEAD/commit-key check to the smoke suite (verifies the feature on the real runtime post-deploy).

`tsc` clean, 69 tests pass (added HEAD-by-sha and HEAD-by-PR), action bundle unaffected. The PR's own staging deploy + smoke is the live verification of HEAD on the real Void runtime.