### PR TITLE
Make smoke-test retry per check (ride out post-deploy edge propagation)

### DIFF
--- a/scripts/smoke-test.mjs
+++ b/scripts/smoke-test.mjs
@@ -101,25 +101,32 @@ const checks = [
 
 console.log(`smoke-testing ${base}`)
 
-// Wait for the new deployment to go live (edge propagation) before asserting.
-for (let i = 0; i < 10; i++) {
-  try {
-    const res = await fetch(`${base}/_health`)
-    if (res.status === 200) break
-  } catch {
-    // not up yet
-  }
-  await sleep(3000)
-}
-
+// Retry each check until it passes or a shared deadline, to ride out edge
+// propagation right after a deploy: a fresh `void deploy` returns before the new
+// worker is live on every edge node, and `/_health` is 200 on both old and new
+// code, so it alone can't tell them apart (this caused a false prod-smoke
+// failure where HEAD briefly hit an old node, x-commit-key=null). A genuinely
+// failing check exhausts the deadline; later checks then fail fast.
+const deadline = Date.now() + 60_000
 let failed = 0
 for (const check of checks) {
-  try {
-    await check.run()
-    console.log(`  ✓ ${check.name}`)
-  } catch (err) {
+  let err
+  for (;;) {
+    err = undefined
+    try {
+      await check.run() // logs the response on every attempt
+      break
+    } catch (e) {
+      err = e
+      if (Date.now() >= deadline) break
+      await sleep(4000)
+    }
+  }
+  if (err) {
     console.error(`  ✗ ${check.name}: ${err.message}`)
     failed++
+  } else {
+    console.log(`  ✓ ${check.name}`)
   }
 }
 


### PR DESCRIPTION
Fixes a false failure in #31's production smoke step.

## What happened

The prod smoke ran immediately after `void deploy` returned and hit an edge node **still serving the old worker**, so `HEAD …@<sha>` came back with `x-commit-key=null` and the check failed. Production was actually healthy (verified `x-commit-key=voidzero-dev:vite-plus:6acea…` seconds later). `/_health` is `200` on both old and new code, so the old `waitForLive` gate couldn't tell propagation hadn't finished.

## Fix

`scripts/smoke-test.mjs` now **retries each check until a shared 60s deadline**, so edge propagation right after a deploy self-heals. A genuinely failing check exhausts the deadline (then later checks fail fast), so real failures are still caught, just not raced. Each attempt still prints its response.

Verified against production (all 5 checks pass, first try each). No `src` change.

Note: #31's deploy run is red on the prod-smoke step, but production is healthy; the next deploy (once this merges) will be green.