### PR TITLE
Cache the npm time map in KV (Void forbids the Cache API)

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ curl -X POST -H "authorization: Bearer $ADMIN_TOKEN" -H 'content-type: applicati
 curl -X DELETE -H "authorization: Bearer $ADMIN_TOKEN" -H 'content-type: application/json' \
   -d '{"ref":"commit.a832a55"}' https://.../-/refs
 
-# Purge a generated build from the caches (R2 + edge)
+# Purge a generated build (its tarball + meta) from R2
 curl -X POST -H "authorization: Bearer $ADMIN_TOKEN" -H 'content-type: application/json' \
   -d '{"package":"vite-plus","version":"0.0.0-commit.a832a55"}' https://.../-/purge
 ```

--- a/src/app.ts
+++ b/src/app.ts
@@ -296,7 +296,7 @@ app.delete('/-/refs', async (c) => {
 })
 
 /**
- * Purge a generated build from the caches. Body:
+ * Purge a generated build from R2. Body:
  * `{ "package": "vite-plus", "version": "0.0.0-commit.<sha>" }`.
  */
 app.post('/-/purge', async (c) => {
@@ -318,7 +318,6 @@ app.post('/-/purge', async (c) => {
   await Promise.all([
     c.env.STORAGE.delete(tarballKey(name, version)),
     c.env.STORAGE.delete(metaKey(name, version)),
-    caches.default.delete(new Request(tarballUrl(c.env, name, version))),
   ])
   return c.json({ purged: { package: name, version } })
 })

--- a/src/cache/headers.ts
+++ b/src/cache/headers.ts
@@ -16,12 +16,3 @@ export function tarballCacheControl(): string {
 export function packumentCacheControl(): string {
   return SHORT_MAX_AGE
 }
-
-/**
- * Cache policy for the cached npm `time` map. Short for its OWN reason, bounding
- * how long a brand-new npm version's time lags, which is independent of the
- * packument TTL even though they currently share a value.
- */
-export function npmTimeCacheControl(): string {
-  return SHORT_MAX_AGE
-}

--- a/src/config.ts
+++ b/src/config.ts
@@ -34,6 +34,11 @@ export interface Env {
    * Also holds the runtime-registered refs index (see getConfiguredRefs).
    */
   STORAGE: R2Bucket
+  /**
+   * KV namespace caching npm's per-version `time` map (small, TTL'd). Used
+   * instead of the Cache API, which the Void runtime forbids.
+   */
+  KV: KVNamespace
   /** Bearer token guarding the admin endpoints (`/-/refs`, `/-/purge`, etc.). */
   ADMIN_TOKEN?: string
 }

--- a/src/registry/fetchNpmPackument.ts
+++ b/src/registry/fetchNpmPackument.ts
@@ -1,7 +1,6 @@
 import type { Env } from '../config'
 import { encodeNpmPackageName } from './parsePackageName'
 import { HttpError } from '../httpError'
-import { npmTimeCacheControl } from '../cache/headers'
 
 // Abbreviated packument format. Always request this from npm: it is an order
 // of magnitude smaller than the full packument (which some clients' Accept
@@ -81,48 +80,37 @@ async function fetchNpmTime(
     : null
 }
 
+/** Cached npm `time` TTL: short, only to bound a brand-new version's lag. */
+const NPM_TIME_TTL_S = 5 * 60
+
 /**
- * npm's per-version `time` map, cached per-colo so the FULL packument (an order
- * of magnitude larger than the abbreviated one, e.g. ~1.4 MB for vite-plus) is
+ * npm's per-version `time` map, cached in KV so the FULL packument (an order of
+ * magnitude larger than the abbreviated one, e.g. ~1.4 MB for vite-plus) is
  * fetched and parsed rarely instead of on every request, the dominant hot-path
- * allocation. Past versions' times are immutable; the short TTL only bounds how
- * long a brand-new npm version's time lags, and such a version is younger than
- * any minimum-release-age threshold (so a momentarily-absent entry is filtered
- * out, not an ERR_PNPM_MISSING_TIME). Refs/versions stay fresh (read live), so
- * this adds no publish-visibility lag.
+ * allocation. KV's native TTL bounds how long a brand-new npm version's time
+ * lags, and such a version is younger than any minimum-release-age threshold (so
+ * a momentarily-absent entry is filtered out, not an ERR_PNPM_MISSING_TIME).
+ * Refs/versions stay fresh (read live), so this adds no publish-visibility lag.
+ * KV, not the Cache API, because the Void runtime forbids `caches.default`.
  */
 export async function getNpmTimeCached(
   env: Env,
   name: string,
 ): Promise<Record<string, string>> {
-  const key = new Request(
-    `${env.PUBLIC_BASE_URL}/-/npm-time/${encodeNpmPackageName(name)}`,
-  )
-  // The Cache API isn't guaranteed on every runtime this deploys to; degrade to
-  // a direct fetch on any cache error rather than failing the request.
+  const key = `npm-time/${name}`
+  // Degrade to a direct fetch on any cache error rather than failing the request.
   try {
-    const hit = await caches.default.match(key)
-    if (hit) return (await hit.json()) as Record<string, string>
+    const cached = await env.KV.get<Record<string, string>>(key, 'json')
+    if (cached) return cached
   } catch (err) {
     console.warn(`npm-time cache read failed for ${name}:`, err)
-    return (await fetchNpmTime(env, name)) ?? {}
   }
 
   // Store the small EXTRACTED map (not the multi-MB body); `{}` for a 404 so a
   // not-on-npm package isn't re-fetched in full every request.
   const time = (await fetchNpmTime(env, name)) ?? {}
   try {
-    // Awaited (not waitUntil) so it works without an ExecutionContext, which the
-    // managed runtime does not always provide; the write is fast and miss-only.
-    await caches.default.put(
-      key,
-      new Response(JSON.stringify(time), {
-        headers: {
-          'content-type': 'application/json',
-          'cache-control': npmTimeCacheControl(),
-        },
-      }),
-    )
+    await env.KV.put(key, JSON.stringify(time), { expirationTtl: NPM_TIME_TTL_S })
   } catch (err) {
     // Best-effort cache population; log so a failing runtime is visible.
     console.warn(`npm-time cache write failed for ${name}:`, err)

--- a/test/worker.test.ts
+++ b/test/worker.test.ts
@@ -33,6 +33,10 @@ const NPM_VITE_PLUS_TIME = {
   '0.2.1': '2026-06-18T05:33:32.399Z',
 }
 
+// Counts fetches of the FULL (time-bearing) vite-plus packument, to verify the
+// KV time-map cache prevents a per-request refetch.
+let fullTimeFetches = 0
+
 function json(obj: unknown, status = 200): Response {
   return new Response(JSON.stringify(obj), {
     status,
@@ -90,6 +94,7 @@ beforeAll(async () => {
         h instanceof Headers ? h.get('accept') : (h as Record<string, string>)?.accept
       ) ?? ''
       const abbreviated = accept.includes('install-v1')
+      if (!abbreviated) fullTimeFetches++
       const body = abbreviated
         ? { ...NPM_VITE_PLUS, modified: NPM_VITE_PLUS_TIME.modified }
         : { ...NPM_VITE_PLUS, time: NPM_VITE_PLUS_TIME }
@@ -180,6 +185,17 @@ describe('packument endpoint', () => {
     expect(b['0.2.1']).toBe('2026-06-18T05:33:32.399Z')
     // the preview time is still injected on every request (not lost to caching).
     expect(b['0.0.0-commit.a832a55']).toBeTruthy()
+  })
+
+  it('caches the npm time map in KV (full packument fetched at most once)', async () => {
+    const before = fullTimeFetches
+    const get = () =>
+      SELF.fetch(`${BASE}/vite-plus`, { headers: { accept: 'application/json' } })
+    await get()
+    await get()
+    // With the KV cache the full (time-bearing) packument is fetched at most
+    // once across the two requests; without it each request would refetch it.
+    expect(fullTimeFetches - before).toBeLessThanOrEqual(1)
   })
 
   it('stamps the preview release date server-side at publish, stable across requests', async () => {

--- a/void.json
+++ b/void.json
@@ -4,7 +4,8 @@
   "inference": {
     "appType": "void",
     "bindings": {
-      "storage": true
+      "storage": true,
+      "kv": true
     }
   },
   "worker": {

--- a/wrangler.test.jsonc
+++ b/wrangler.test.jsonc
@@ -12,6 +12,7 @@
   "r2_buckets": [
     { "binding": "STORAGE", "bucket_name": "pkg-pr-registry-bridge-tarballs" }
   ],
+  "kv_namespaces": [{ "binding": "KV", "id": "test-npm-time-cache" }],
   "vars": {
     "NPM_REGISTRY": "https://registry.npmjs.org",
     "PKG_PR_NEW_BASE": "https://pkg.pr.new",


### PR DESCRIPTION
Re-does the time-map cache (originally on `caches.default` in #26) on **Cloudflare KV**, the right primitive on Void.

## Why KV

The Void runtime **forbids `caches.default`** ("not permitted to access the default cache"), which is what 500'd every packument in #26 and, after the #28 guard, left the cache inert + logged a warn on every request. KV works on Void and has a **native TTL**, so no hand-tracked timestamp like R2 would need.

## Change

- `void.json` adds the `kv` binding (auto-provisioned on deploy); `env.KV` added to the Env type.
- `getNpmTimeCached` now reads/writes the extracted `time` map in KV with `expirationTtl: 300`. The full 1.4 MB packument is fetched + parsed only on a miss (~once per TTL, globally) instead of every request, the original memory/CPU win, now actually delivered on Void.
- Drops `/-/purge`'s `caches.default.delete`, the last Cache-API user (a no-op that would 500 on Void). The codebase no longer touches `caches.default`.

## Verified on the real Void runtime

Deployed to staging (`Provisioning kv:KV`); `/vite-plus` serves the time map (138 entries) with **no cache warns** in the logs (vs the pre-KV deploy which spammed "not permitted to access the default cache"). 

`tsc` clean, 70 tests pass (added: full packument fetched at most once across two requests), action bundle unaffected. The PR's own staging deploy + smoke re-verifies on Void.