### PR TITLE
Add CORS (access-control-allow-origin: *) so browsers can use the API

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -1,4 +1,5 @@
 import { Hono } from 'hono'
+import { cors } from 'hono/cors'
 import type { ContentfulStatusCode } from 'hono/utils/http-status'
 import type { Env } from './config'
 import { HttpError } from './httpError'
@@ -50,6 +51,10 @@ const UNPUBLISHED_PREVIEW_TIME = '2020-01-01T00:00:00.000Z'
 type HonoEnv = { Bindings: Env }
 
 export const app = new Hono<HonoEnv>()
+
+// Allow browser clients to read every response (this is a public, read-mostly
+// registry API). Mirrors pkg.pr.new's `access-control-allow-origin: *`.
+app.use('*', cors())
 
 app.get('/_health', (c) => c.json({ status: 'ok' }))
 
@@ -433,6 +438,8 @@ app.get('*', async (c) => {
 app.all('*', (c) => redirectToNpm(c.env, c.req.raw))
 
 app.onError((err, c) => {
+  // Keep the CORS header on errors too, so a browser can read the error body.
+  c.header('access-control-allow-origin', '*')
   if (err instanceof HttpError) {
     return c.json({ error: err.message }, err.status as ContentfulStatusCode)
   }

--- a/test/worker.test.ts
+++ b/test/worker.test.ts
@@ -615,6 +615,42 @@ describe('pkg.pr.new-style download', () => {
   })
 })
 
+describe('CORS', () => {
+  it('sets access-control-allow-origin: * on the packument', async () => {
+    const res = await SELF.fetch(`${BASE}/vite-plus`, {
+      headers: { accept: 'application/json' },
+    })
+    expect(res.status).toBe(200)
+    expect(res.headers.get('access-control-allow-origin')).toBe('*')
+  })
+
+  it('sets the CORS header on /-/refs and the download redirect', async () => {
+    const refs = await SELF.fetch(`${BASE}/-/refs`)
+    expect(refs.headers.get('access-control-allow-origin')).toBe('*')
+    const dl = await SELF.fetch(`${BASE}/voidzero-dev/vite-plus@abc1234`, {
+      redirect: 'manual',
+    })
+    expect(dl.status).toBe(302)
+    expect(dl.headers.get('access-control-allow-origin')).toBe('*')
+  })
+
+  it('sets the CORS header on error responses', async () => {
+    // Unknown package in the download path -> 404 via onError.
+    const res = await SELF.fetch(
+      `${BASE}/voidzero-dev/vite-plus/not-a-pkg@abc1234`,
+      { redirect: 'manual' },
+    )
+    expect(res.status).toBe(404)
+    expect(res.headers.get('access-control-allow-origin')).toBe('*')
+  })
+
+  it('answers an OPTIONS preflight with the CORS header', async () => {
+    const res = await SELF.fetch(`${BASE}/vite-plus`, { method: 'OPTIONS' })
+    expect(res.status).toBeLessThan(300)
+    expect(res.headers.get('access-control-allow-origin')).toBe('*')
+  })
+})
+
 describe('admin: refs', () => {
   it('writes require auth (reads do not)', async () => {
     // POST/DELETE require the bearer token.


### PR DESCRIPTION
Browser clients (a web app `fetch`-ing the registry) can't read responses without CORS. pkg.pr.new sets `access-control-allow-origin: *`; this does the same.

## Change

- `app.use('*', cors())` (Hono) sets `access-control-allow-origin: *` on every response, packuments, `/-/refs`, tarballs, the download URL/`HEAD`, and answers OPTIONS preflight.
- `onError` also sets the header, so a browser can read error bodies (4xx/5xx), not just successes.

npm/pnpm/bun ignore CORS headers, so non-browser clients are unaffected.

`tsc` clean, 74 tests pass (added: header present on the packument, `/-/refs`, the 302 download, error responses, and preflight). Action bundle unaffected.