### PR TITLE
Apply /simplify: smoke runWithRetry; drop redundant onError CORS

### DIFF
--- a/scripts/smoke-test.mjs
+++ b/scripts/smoke-test.mjs
@@ -108,25 +108,28 @@ console.log(`smoke-testing ${base}`)
 // failure where HEAD briefly hit an old node, x-commit-key=null). A genuinely
 // failing check exhausts the deadline; later checks then fail fast.
 const deadline = Date.now() + 60_000
-let failed = 0
-for (const check of checks) {
-  let err
+
+// Run a check (it logs its response each attempt); throw the last error once the
+// deadline passes.
+async function runWithRetry(check) {
   for (;;) {
-    err = undefined
     try {
-      await check.run() // logs the response on every attempt
-      break
-    } catch (e) {
-      err = e
-      if (Date.now() >= deadline) break
+      return await check.run()
+    } catch (err) {
+      if (Date.now() >= deadline) throw err
       await sleep(4000)
     }
   }
-  if (err) {
+}
+
+let failed = 0
+for (const check of checks) {
+  try {
+    await runWithRetry(check)
+    console.log(`  ✓ ${check.name}`)
+  } catch (err) {
     console.error(`  ✗ ${check.name}: ${err.message}`)
     failed++
-  } else {
-    console.log(`  ✓ ${check.name}`)
   }
 }
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -438,8 +438,6 @@ app.get('*', async (c) => {
 app.all('*', (c) => redirectToNpm(c.env, c.req.raw))
 
 app.onError((err, c) => {
-  // Keep the CORS header on errors too, so a browser can read the error body.
-  c.header('access-control-allow-origin', '*')
   if (err instanceof HttpError) {
     return c.json({ error: err.message }, err.status as ContentfulStatusCode)
   }


### PR DESCRIPTION
`/simplify` cleanup over the recent commits (HEAD endpoint, smoke rewrite, KV cache, CORS).

## Applied
- **`scripts/smoke-test.mjs`**: extracted a `runWithRetry(check)` helper, dropping the `for(;;)` loop with a mutable `err` and dual success/deadline `break`s (simplification). Verified: 5/5 smoke checks pass against prod.
- **`src/app.ts`**: removed the manual `access-control-allow-origin` set in `onError`. The altitude agent empirically confirmed (and the CORS-error unit test re-confirms) that Hono's `cors()` sets the header **before** `next()` and `onError`'s `c.json` preserves `c.res` headers, so error responses are already covered. Removes a redundant, drift-prone second hardcoded `'*'`.

## Skipped (with reasons)
- **`npmTimeKey()` builder** (reuse): single call site, already a local `const`, and it's a KV key in the R2-keys module , premature; extract when a second KV key lands.
- **`head`-param → descriptor refactor** (altitude): right depth, single caller; not worth the churn.
- **`getNpmTimeCached` two try-blocks**: different recovery semantics (read falls through to fetch; write is best-effort) and KV's 1-write/s/key rate limit makes the write-catch load-bearing.
- **`/-/purge` `assertPreviewTarget` nit**: pre-existing, outside this diff.

`tsc` clean, 74 tests pass, action bundle unaffected.