### PR TITLE
Cache the abbreviated npm packument in KV

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -23,7 +23,7 @@ import {
   parseUploadPath,
 } from './registry/parsePackageName'
 import {
-  fetchNpmPackument,
+  getNpmPackumentCached,
   getNpmTimeCached,
 } from './registry/fetchNpmPackument'
 import { buildVersionMetadata } from './registry/buildVersionMetadata'
@@ -375,7 +375,7 @@ app.get('*', async (c) => {
   // abbreviated form we serve omits it) but is sourced separately so the served
   // response keeps the compact abbreviated version docs.
   const [base, npmTime, refs] = await Promise.all([
-    fetchNpmPackument(c.env, name),
+    getNpmPackumentCached(c.env, name),
     getNpmTimeCached(c.env, name),
     getConfiguredRefs(c.env),
   ])

--- a/src/cache/kvCache.ts
+++ b/src/cache/kvCache.ts
@@ -1,0 +1,38 @@
+import type { Env } from '../config'
+
+/**
+ * Read a JSON value from KV, or compute it and write it back with a TTL.
+ *
+ * Cache errors degrade to a direct compute (logged, never thrown), so a flaky
+ * KV never fails the request. The computed value is returned but only cached
+ * when non-nullish, so the caller controls negative caching by what its fetcher
+ * returns: return `{}` to cache a not-found cheaply, or `null` to leave it
+ * uncached. `KV.get(..., 'json')` returns a fresh parse each call, so the caller
+ * may safely mutate the result without corrupting the cache.
+ *
+ * KV, not the Cache API, because the Void runtime forbids `caches.default`.
+ */
+export async function kvCached<T>(
+  env: Env,
+  key: string,
+  ttlSeconds: number,
+  fetcher: () => Promise<T | null>,
+): Promise<T | null> {
+  try {
+    const cached = await env.KV.get<T>(key, 'json')
+    if (cached != null) return cached
+  } catch (err) {
+    console.warn(`KV cache read failed for ${key}:`, err)
+  }
+
+  const value = await fetcher()
+  if (value != null) {
+    try {
+      await env.KV.put(key, JSON.stringify(value), { expirationTtl: ttlSeconds })
+    } catch (err) {
+      // Best-effort population; log so a failing runtime stays visible.
+      console.warn(`KV cache write failed for ${key}:`, err)
+    }
+  }
+  return value
+}

--- a/src/registry/fetchNpmPackument.ts
+++ b/src/registry/fetchNpmPackument.ts
@@ -117,3 +117,46 @@ export async function getNpmTimeCached(
   }
   return time
 }
+
+/** Cached abbreviated packument TTL: matches the served `cache-control` window. */
+const NPM_PACKUMENT_TTL_S = 5 * 60
+
+/**
+ * The abbreviated npm packument, cached in KV. The Void runtime does NOT
+ * edge-cache the assembled packument response (it forbids the Cache API), so
+ * without this every fresh client, e.g. each CI install, re-fetched the full
+ * abbreviated packument from npm cross-network, the dominant hot-path latency.
+ * Only npm-published versions are cached; preview versions are injected live
+ * from the refs index, so a newly published preview still appears immediately
+ * (the cache adds no publish-visibility lag, only an npm stable release lags up
+ * to the TTL, which the served `max-age=300` already allows). A 404 (not on npm)
+ * is not cached; a fresh per-call parse means the caller can mutate the result
+ * without corrupting the cache. KV, not the Cache API, per the Void ban.
+ */
+export async function getNpmPackumentCached(
+  env: Env,
+  name: string,
+): Promise<Record<string, any> | null> {
+  const key = `npm-packument/${name}`
+  // Degrade to a direct fetch on any cache error rather than failing the request.
+  try {
+    const cached = await env.KV.get<Record<string, any>>(key, 'json')
+    if (cached) return cached
+  } catch (err) {
+    console.warn(`npm-packument cache read failed for ${name}:`, err)
+  }
+
+  // A non-200/404 throws (surfaces the upstream error); a 404 returns null and is
+  // left uncached so a not-on-npm package stays cheap to re-probe.
+  const packument = await fetchNpmPackument(env, name)
+  if (packument) {
+    try {
+      await env.KV.put(key, JSON.stringify(packument), {
+        expirationTtl: NPM_PACKUMENT_TTL_S,
+      })
+    } catch (err) {
+      console.warn(`npm-packument cache write failed for ${name}:`, err)
+    }
+  }
+  return packument
+}

--- a/src/registry/fetchNpmPackument.ts
+++ b/src/registry/fetchNpmPackument.ts
@@ -1,6 +1,7 @@
 import type { Env } from '../config'
 import { encodeNpmPackageName } from './parsePackageName'
 import { HttpError } from '../httpError'
+import { kvCached } from '../cache/kvCache'
 
 // Abbreviated packument format. Always request this from npm: it is an order
 // of magnitude smaller than the full packument (which some clients' Accept
@@ -97,25 +98,14 @@ export async function getNpmTimeCached(
   env: Env,
   name: string,
 ): Promise<Record<string, string>> {
-  const key = `npm-time/${name}`
-  // Degrade to a direct fetch on any cache error rather than failing the request.
-  try {
-    const cached = await env.KV.get<Record<string, string>>(key, 'json')
-    if (cached) return cached
-  } catch (err) {
-    console.warn(`npm-time cache read failed for ${name}:`, err)
-  }
-
-  // Store the small EXTRACTED map (not the multi-MB body); `{}` for a 404 so a
-  // not-on-npm package isn't re-fetched in full every request.
-  const time = (await fetchNpmTime(env, name)) ?? {}
-  try {
-    await env.KV.put(key, JSON.stringify(time), { expirationTtl: NPM_TIME_TTL_S })
-  } catch (err) {
-    // Best-effort cache population; log so a failing runtime is visible.
-    console.warn(`npm-time cache write failed for ${name}:`, err)
-  }
-  return time
+  // The fetcher returns the small EXTRACTED map (not the multi-MB body), and `{}`
+  // for a 404 so a not-on-npm package is cached and not re-fetched in full every
+  // request.
+  return (
+    (await kvCached(env, `npm-time/${name}`, NPM_TIME_TTL_S, async () =>
+      (await fetchNpmTime(env, name)) ?? {},
+    )) ?? {}
+  )
 }
 
 /** Cached abbreviated packument TTL: matches the served `cache-control` window. */
@@ -130,33 +120,13 @@ const NPM_PACKUMENT_TTL_S = 5 * 60
  * from the refs index, so a newly published preview still appears immediately
  * (the cache adds no publish-visibility lag, only an npm stable release lags up
  * to the TTL, which the served `max-age=300` already allows). A 404 (not on npm)
- * is not cached; a fresh per-call parse means the caller can mutate the result
- * without corrupting the cache. KV, not the Cache API, per the Void ban.
+ * returns null and is left uncached so it stays cheap to re-probe.
  */
-export async function getNpmPackumentCached(
+export function getNpmPackumentCached(
   env: Env,
   name: string,
 ): Promise<Record<string, any> | null> {
-  const key = `npm-packument/${name}`
-  // Degrade to a direct fetch on any cache error rather than failing the request.
-  try {
-    const cached = await env.KV.get<Record<string, any>>(key, 'json')
-    if (cached) return cached
-  } catch (err) {
-    console.warn(`npm-packument cache read failed for ${name}:`, err)
-  }
-
-  // A non-200/404 throws (surfaces the upstream error); a 404 returns null and is
-  // left uncached so a not-on-npm package stays cheap to re-probe.
-  const packument = await fetchNpmPackument(env, name)
-  if (packument) {
-    try {
-      await env.KV.put(key, JSON.stringify(packument), {
-        expirationTtl: NPM_PACKUMENT_TTL_S,
-      })
-    } catch (err) {
-      console.warn(`npm-packument cache write failed for ${name}:`, err)
-    }
-  }
-  return packument
+  return kvCached(env, `npm-packument/${name}`, NPM_PACKUMENT_TTL_S, () =>
+    fetchNpmPackument(env, name),
+  )
 }

--- a/test/worker.test.ts
+++ b/test/worker.test.ts
@@ -36,6 +36,9 @@ const NPM_VITE_PLUS_TIME = {
 // Counts fetches of the FULL (time-bearing) vite-plus packument, to verify the
 // KV time-map cache prevents a per-request refetch.
 let fullTimeFetches = 0
+// Counts fetches of the ABBREVIATED vite-plus packument, to verify the KV
+// packument cache prevents a per-request refetch.
+let abbreviatedFetches = 0
 
 function json(obj: unknown, status = 200): Response {
   return new Response(JSON.stringify(obj), {
@@ -94,7 +97,8 @@ beforeAll(async () => {
         h instanceof Headers ? h.get('accept') : (h as Record<string, string>)?.accept
       ) ?? ''
       const abbreviated = accept.includes('install-v1')
-      if (!abbreviated) fullTimeFetches++
+      if (abbreviated) abbreviatedFetches++
+      else fullTimeFetches++
       const body = abbreviated
         ? { ...NPM_VITE_PLUS, modified: NPM_VITE_PLUS_TIME.modified }
         : { ...NPM_VITE_PLUS, time: NPM_VITE_PLUS_TIME }
@@ -198,6 +202,18 @@ describe('packument endpoint', () => {
     expect(fullTimeFetches - before).toBeLessThanOrEqual(1)
   })
 
+  it('caches the abbreviated packument in KV (fetched at most once)', async () => {
+    // The Void runtime does not edge-cache the assembled response, so without
+    // this KV cache every fresh client would re-fetch the abbreviated packument
+    // from npm. Two requests must hit npm for it at most once.
+    const before = abbreviatedFetches
+    const get = () =>
+      SELF.fetch(`${BASE}/vite-plus`, { headers: { accept: 'application/json' } })
+    await get()
+    await get()
+    expect(abbreviatedFetches - before).toBeLessThanOrEqual(1)
+  })
+
   it('stamps the preview release date server-side at publish, stable across requests', async () => {
     // The release date is stamped server-side once at publish, not npm's
     // package-modified time, not a per-request clock, and not a client value.
@@ -265,13 +281,15 @@ describe('packument endpoint', () => {
   it('surfaces an npm registry error (non-200, non-404) instead of synthesizing', async () => {
     // 404 means "not on npm" and is synthesized (above). Any other upstream
     // error must propagate npm's status, not hide behind a 200 packument that
-    // silently drops the package's real versions.
+    // silently drops the package's real versions. Use a workspace package the
+    // suite never fetches, so the npm packument is a cold KV miss (a warm cache
+    // would, by design, ride out the blip and serve the cached packument).
     const saved = globalThis.fetch
     vi.stubGlobal('fetch', () =>
       Promise.resolve(json({ error: 'upstream boom' }, 503)),
     )
     try {
-      const res = await SELF.fetch(`${BASE}/vite-plus`, {
+      const res = await SELF.fetch(`${BASE}/@voidzero-dev%2Fvite-plus-uncached`, {
         headers: { accept: 'application/json' },
       })
       expect(res.status).toBe(503)


### PR DESCRIPTION
## Why

Probed prod: the assembled packument is **not edge-cached** on Void (no `cf-cache-status`, and its ~432KB body is rebuilt on every request), because the runtime forbids the Cache API. So every fresh client (notably each CI install) re-fetched the full abbreviated packument from npm cross-network, the dominant hot-path latency. The tarball path, by contrast, *is* edge-cached (`cf-cache-status: HIT`).

## What

`getNpmPackumentCached` mirrors the proven `getNpmTimeCached`: KV, 5min TTL.

- Only a 200 is cached; a 404 stays uncached (a not-on-npm package is cheap to re-probe), and any other upstream error still surfaces on a cache miss.
- Preview versions are injected live from the refs index, not from `base`, so a newly published preview appears immediately, no publish-visibility lag. Only an npm stable release can lag up to the TTL, which the served `max-age=300` already permits.
- A warm cache also rides out a transient npm blip (this changed one test, which now exercises the surface-the-error invariant on a cold-cache package).

## Verify

`tsc` clean, 75 tests pass (added: abbreviated packument fetched at most once across two requests). The staging smoke gate exercises it on the real runtime before prod.