### PR TITLE
Drop VITE_PLUS_PREVIEW_REFS (preview refs are runtime-only)

### DIFF
--- a/.env
+++ b/.env
@@ -9,9 +9,6 @@ NPM_REGISTRY=https://registry.npmjs.org
 PKG_PR_NEW_BASE=https://pkg.pr.new
 PREVIEW_OWNER=voidzero-dev
 PREVIEW_REPO=vite-plus
-# Comma-separated commit refs to inject into packuments: `commit.<sha>`.
-# Only immutable commit builds are supported (PR-number refs are rejected).
-VITE_PLUS_PREVIEW_REFS=commit.6acea1aa818e96365b5811d47360367ba18a3a05
 # Packages the tarball endpoint serves and whose pkg.pr.new dependency URLs are
 # routed through the bridge. Exact names or `prefix*` patterns.
 WORKSPACE_PACKAGES=vite-plus,@voidzero-dev/vite-plus-*

--- a/README.md
+++ b/README.md
@@ -114,21 +114,21 @@ networkConcurrency = 8
 > mirror configured, unset that override or run bun directly so the bridge
 > registry is used.
 
-## Why preview refs are configured (`VITE_PLUS_PREVIEW_REFS`)
+## Why the bridge needs a list of preview refs
 
 A package manager fetches the **packument** (`GET /vite-plus`) to discover which
 versions exist *before* it resolves a version, and the request carries no
 desired-version hint. So the bridge has to know which synthetic preview versions
 to list in that packument. pkg.pr.new has no API to enumerate its builds as
-semver versions, so the set is configured explicitly.
+semver versions, so the set is maintained explicitly.
 
 The tarball endpoint, by contrast, accepts any valid preview version without
 configuration; only packument-based discovery needs the list.
 
-The static `VITE_PLUS_PREVIEW_REFS` var is one source; refs can also be added at
-runtime via the admin endpoint below (stored in a single R2 index object read
-with a cheap `get`, not a rate-limited KV `list`), with no redeploy. Both
-sources are merged.
+Refs are registered at runtime via the admin endpoints below (the publish action
+calls them from CI), stored in a single R2 index object read with a cheap `get`
+(not a rate-limited KV `list`) and pruned by a TTL. No redeploy and no static
+configuration: a published preview appears as soon as the action registers it.
 
 For refs published from a PR (the action forwards the PR url), the served
 packument also exposes a `pr-<n>` dist-tag pointing at that PR's
@@ -224,7 +224,6 @@ are uploaded with `void secret put`:
 | `NPM_REGISTRY` | npm fallback registry (`https://registry.npmjs.org`). |
 | `PKG_PR_NEW_BASE` | pkg.pr.new base (`https://pkg.pr.new`). |
 | `PREVIEW_OWNER` / `PREVIEW_REPO` | Fixed upstream repo (`voidzero-dev` / `vite-plus`). |
-| `VITE_PLUS_PREVIEW_REFS` | Comma-separated commit refs to inject: `commit.<sha>` (PR refs rejected). |
 | `WORKSPACE_PACKAGES` | Allowlist for the tarball endpoint and pkg.pr.new-URL dep routing. Exact names or `prefix*`, e.g. `vite-plus,@voidzero-dev/vite-plus-*`. |
 | `MAX_TARBALL_BYTES` | Max upstream tarball size (default 64 MiB). |
 

--- a/env.ts
+++ b/env.ts
@@ -14,8 +14,6 @@ export default defineEnv({
   // Fixed upstream owner/repo; never selected by request input.
   PREVIEW_OWNER: string(),
   PREVIEW_REPO: string(),
-  // Comma-separated commit refs to inject into packuments: `commit.<sha>`.
-  VITE_PLUS_PREVIEW_REFS: string(),
   // Allowlist of packages the bridge serves/routes (exact names or `prefix*`).
   WORKSPACE_PACKAGES: string(),
   // Max upstream tarball size in bytes.

--- a/examples/bun-validation/README.md
+++ b/examples/bun-validation/README.md
@@ -33,5 +33,5 @@ bunx vp --version
 ```
 
 To target a different preview build, change the `0.0.0-commit.<sha>` version in
-`package.json`, and make sure that ref is exposed by the bridge via
-`VITE_PLUS_PREVIEW_REFS`.
+`package.json`, and make sure that ref has been published to the bridge (CI's
+publish action does this).

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "dev": "vite dev",
     "build": "vite build",
     "prepare": "void prepare",
-    "deploy": "void deploy && node scripts/warm.mjs && node scripts/e2e-bun.mjs",
+    "deploy": "void deploy && node scripts/e2e-bun.mjs",
     "deploy:only": "void deploy",
     "warm": "node scripts/warm.mjs",
     "smoke": "node scripts/smoke-test.mjs",

--- a/scripts/e2e-bun.mjs
+++ b/scripts/e2e-bun.mjs
@@ -6,10 +6,10 @@
 // installed packages resolved to the synthetic preview version (which only the
 // bridge can serve). Intended to run after every deploy (`pnpm deploy`).
 //
-// Config (all optional; sensible defaults read from .env / .env.production):
-//   BRIDGE_URL         override the bridge origin (default: PUBLIC_BASE_URL)
-//   BRIDGE_E2E_REF     preview ref to test, e.g. `commit.<sha>` (default: first
-//                      of VITE_PLUS_PREVIEW_REFS)
+// Config (all optional):
+//   BRIDGE_URL         override the bridge origin (default: PUBLIC_BASE_URL from .env)
+//   BRIDGE_E2E_REF     preview ref to test, e.g. `commit.<sha>` (default: the
+//                      first ref the bridge currently lists at /-/refs)
 //   BRIDGE_E2E_VERSION explicit synthetic version, e.g. `0.0.0-commit.<sha>`
 //                      (overrides BRIDGE_E2E_REF)
 import { execFileSync } from 'node:child_process'
@@ -31,29 +31,32 @@ async function waitForHealth(base) {
   throw new Error(`bridge health check never passed at ${base}/_health`)
 }
 
+// The synthetic version to validate: an explicit override, else the first ref
+// the live bridge currently lists. Preview refs are registered at runtime (CI /
+// admin), not static config, so the test discovers one from the deployment
+// rather than reading it from `.env`.
+async function resolveVersion(base) {
+  if (process.env.BRIDGE_E2E_VERSION) return process.env.BRIDGE_E2E_VERSION
+  if (process.env.BRIDGE_E2E_REF) return refToVersion(process.env.BRIDGE_E2E_REF)
+  try {
+    const res = await fetch(`${base}/-/refs`)
+    const { refs } = await res.json()
+    const first = Array.isArray(refs) ? refs[0] : null
+    return first?.version ?? (first?.ref ? refToVersion(first.ref) : null)
+  } catch {
+    return null
+  }
+}
+
 const config = readConfig()
 const bridgeUrl = (process.env.BRIDGE_URL || config.baseUrl || '').replace(
   /\/+$/,
   '',
 )
-const ref = (
-  process.env.BRIDGE_E2E_REF ||
-  config.refs.split(',')[0] ||
-  ''
-).trim()
-const version =
-  process.env.BRIDGE_E2E_VERSION || (ref ? refToVersion(ref) : null)
 
 if (!bridgeUrl) {
   console.error('e2e: could not determine bridge URL (set BRIDGE_URL)')
   process.exit(1)
-}
-if (!version) {
-  console.log(
-    'e2e: no preview ref configured (VITE_PLUS_PREVIEW_REFS empty); ' +
-      'nothing to validate, skipping.',
-  )
-  process.exit(0)
 }
 
 try {
@@ -63,8 +66,17 @@ try {
   process.exit(1)
 }
 
-console.log(`e2e: validating ${version} via ${bridgeUrl}`)
 await waitForHealth(bridgeUrl)
+
+const version = await resolveVersion(bridgeUrl)
+if (!version) {
+  console.log(
+    'e2e: no preview ref available on the bridge; nothing to validate, skipping.',
+  )
+  process.exit(0)
+}
+
+console.log(`e2e: validating ${version} via ${bridgeUrl}`)
 
 const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'bridge-e2e-'))
 let exitCode = 0

--- a/scripts/lib/config.mjs
+++ b/scripts/lib/config.mjs
@@ -1,7 +1,9 @@
 // Shared helpers for the deploy-time scripts (warm.mjs, e2e-bun.mjs).
-// Reads the bridge origin and preview refs from the committed `.env` files
-// (Void's source of truth for worker vars), with `.env.production` overriding
-// `.env`. Override at runtime with BRIDGE_URL / BRIDGE_E2E_REF.
+// Reads the bridge origin from the committed `.env` files (Void's source of
+// truth for worker vars), with `.env.production` overriding `.env`. Override at
+// runtime with BRIDGE_URL. Preview refs are no longer static config; they are
+// registered at runtime (CI / admin endpoints), so the scripts discover them
+// from the live bridge instead.
 import fs from 'node:fs'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -34,7 +36,7 @@ function parseEnvFile(file) {
   return out
 }
 
-/** Read PUBLIC_BASE_URL and VITE_PLUS_PREVIEW_REFS from `.env` + `.env.production`. */
+/** Read PUBLIC_BASE_URL from `.env` + `.env.production`. */
 export function readConfig() {
   const merged = {
     ...parseEnvFile(path.join(root, '.env')),
@@ -42,7 +44,6 @@ export function readConfig() {
   }
   return {
     baseUrl: merged.PUBLIC_BASE_URL || '',
-    refs: merged.VITE_PLUS_PREVIEW_REFS || '',
   }
 }
 

--- a/scripts/smoke-test.mjs
+++ b/scripts/smoke-test.mjs
@@ -15,7 +15,10 @@ if (!base) {
   process.exit(2)
 }
 
-// A configured commit ref (also a valid sha for the download endpoint).
+// Any valid commit sha: the download/HEAD checks resolve a sha to its synthetic
+// version without a registry lookup, so this need not be a registered ref. The
+// packument check relies on npm's stable versions, not a preview ref, so the
+// smoke test does not depend on any ref being registered.
 const SHA = '6acea1aa818e96365b5811d47360367ba18a3a05'
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms))
 const truncate = (s, n = 300) => (s.length > n ? `${s.slice(0, n)}…` : s)

--- a/scripts/warm.mjs
+++ b/scripts/warm.mjs
@@ -1,11 +1,11 @@
 #!/usr/bin/env node
-// Publish preview refs to the bridge by running the publish action for each one
-// (build + hash + upload the artifacts in Node, then register the ref). This is
-// the same code path vite-plus's CI uses; here it pre-populates the configured
-// static refs as part of `pnpm deploy`.
+// Publish one or more preview refs to the bridge by running the publish action
+// for each (build + hash + upload the artifacts in Node, then register the ref).
+// This is the same code path vite-plus's CI uses; here it's a manual helper to
+// seed or refresh a specific commit (refs are otherwise registered dynamically
+// by CI, so a normal deploy needs no warming).
 //
 // Usage:
-//   node scripts/warm.mjs                    # publish the refs in .env
 //   node scripts/warm.mjs <sha> [<sha>...]   # publish each commit
 //
 // Needs PKG_PR_BRIDGE_ADMIN_TOKEN (or ADMIN_TOKEN) in the environment.
@@ -36,7 +36,7 @@ function publish(sha, bridge) {
   })
 }
 
-const { baseUrl, refs } = readConfig()
+const { baseUrl } = readConfig()
 const bridge = (process.env.BRIDGE_URL || baseUrl || '').replace(/\/+$/, '')
 if (!bridge) {
   console.error('warm: could not determine bridge URL')
@@ -48,8 +48,7 @@ if (!ADMIN_TOKEN) {
 }
 
 const cliArgs = process.argv.slice(2).map((s) => s.trim()).filter(Boolean)
-const source = cliArgs.length > 0 ? cliArgs : refs.split(',')
-const shas = source.map((s) => s.trim()).filter(Boolean).map((raw) => {
+const shas = cliArgs.map((raw) => {
   const sha = normalizeSha(raw)
   if (!sha) {
     console.error(`warm: invalid commit "${raw}" (expected a sha or commit.<sha>)`)
@@ -59,7 +58,7 @@ const shas = source.map((s) => s.trim()).filter(Boolean).map((raw) => {
 })
 
 if (shas.length === 0) {
-  console.log('warm: no preview refs configured; nothing to publish.')
+  console.log('warm: no commit shas given; nothing to publish (refs register dynamically).')
   process.exit(0)
 }
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -52,23 +52,11 @@ const UNPUBLISHED_PREVIEW_TIME = '2020-01-01T00:00:00.000Z'
 
 // Output cache for the assembled packument. Void does not edge-cache the Worker
 // response, so without this the ~440KB packument is re-assembled and re-stringified
-// on every request. Keyed by the refs-index etag + a hash of the static env refs;
-// a short TTL bounds npm stable-version drift (preview freshness comes from the
-// etag, not the TTL).
+// on every request. Keyed by the refs-index etag, which changes on every ref
+// mutation; a short TTL bounds npm stable-version drift (preview freshness comes
+// from the etag, not the TTL).
 const PACKUMENT_OUT_PREFIX = 'pkgt/'
 const PACKUMENT_OUT_TTL_S = 60
-
-/**
- * Stable short hash of the static env-configured refs (VITE_PLUS_PREVIEW_REFS),
- * folded into the output-cache key. KV persists across deploys, so the key must
- * change when these change; the R2 etag only covers runtime ref changes.
- */
-function hashRefsEnv(refs: string | undefined): string {
-  let h = 5381
-  const s = refs ?? ''
-  for (let i = 0; i < s.length; i++) h = (Math.imul(h, 33) + s.charCodeAt(i)) | 0
-  return (h >>> 0).toString(36)
-}
 
 /** Build the packument HTTP response from an already-serialized body. */
 function packumentResponse(body: string): Response {
@@ -408,7 +396,7 @@ app.get('*', async (c) => {
   // consistent read-after-write, so a just-published preview shows up on the very
   // next request.
   const { refs, etag } = await getConfiguredRefsWithEtag(c.env)
-  const cacheKey = `${PACKUMENT_OUT_PREFIX}${name}/${etag ?? 'none'}.${hashRefsEnv(c.env.VITE_PLUS_PREVIEW_REFS)}`
+  const cacheKey = `${PACKUMENT_OUT_PREFIX}${name}/${etag ?? 'none'}`
 
   const body = await kvCachedText(c.env, cacheKey, PACKUMENT_OUT_TTL_S, async () => {
     // Miss: the npm packument fetch and the npm `time` fetch are independent, so

--- a/src/config.ts
+++ b/src/config.ts
@@ -15,8 +15,6 @@ export interface Env {
   PREVIEW_OWNER: string
   /** Fixed upstream repo; never selected by request input. */
   PREVIEW_REPO: string
-  /** Comma-separated commit refs to inject, e.g. `commit.a832a55`. */
-  VITE_PLUS_PREVIEW_REFS: string
   /**
    * Comma-separated allowlist of packages the tarball endpoint may serve and
    * whose pkg.pr.new dependency URLs are routed through the bridge. Entries are

--- a/src/preview/getConfiguredRefs.ts
+++ b/src/preview/getConfiguredRefs.ts
@@ -1,7 +1,6 @@
 import type { Env } from '../config'
 import {
   parseConfiguredPreviewRefs,
-  parseConfiguredPreviewRefsSafe,
   parseSingleRef,
   prNumberFromUrl,
   type ConfiguredPreviewRef,
@@ -69,20 +68,17 @@ async function mutateRefIndex(
 }
 
 /**
- * Resolve the preview refs to inject into packuments: the static
- * `VITE_PLUS_PREVIEW_REFS` var merged with refs registered at runtime in R2.
+ * Resolve the preview refs to inject into packuments, from the runtime refs
+ * index in R2 (registered via the admin endpoints / the publish action). Also
+ * returns the index etag, which changes on every ref mutation, so callers that
+ * cache derived output can invalidate on any ref change. Null etag when the
+ * index is absent or unreadable.
  */
 export async function getConfiguredRefsWithEtag(
   env: Env,
 ): Promise<{ refs: ConfiguredPreviewRef[]; etag: string | null }> {
-  const fromEnv = parseConfiguredPreviewRefsSafe(env.VITE_PLUS_PREVIEW_REFS)
-
-  // The R2 index etag changes on every ref mutation (register/publish/unregister
-  // all rewrite the object), so it doubles as a cheap version stamp for callers
-  // that cache derived output and want to invalidate on any ref change. Null when
-  // the index is absent or unreadable.
   let etag: string | null = null
-  const fromR2: ConfiguredPreviewRef[] = []
+  const refs: ConfiguredPreviewRef[] = []
   try {
     const { index, etag: indexEtag } = await readRefIndex(env)
     etag = indexEtag
@@ -93,7 +89,7 @@ export async function getConfiguredRefsWithEtag(
       if (entry.expiresAt <= now) continue
       const parsed = parseSingleRef(key)
       if (!parsed) continue
-      fromR2.push({
+      refs.push({
         ...parsed,
         publishedAt: entry.publishedAt,
         prUrl: entry.prUrl,
@@ -105,9 +101,7 @@ export async function getConfiguredRefsWithEtag(
     console.warn('Failed to read preview refs from R2:', err)
   }
 
-  const byVersion = new Map<string, ConfiguredPreviewRef>()
-  for (const ref of [...fromEnv, ...fromR2]) byVersion.set(ref.version, ref)
-  return { refs: [...byVersion.values()], etag }
+  return { refs, etag }
 }
 
 export async function getConfiguredRefs(

--- a/src/preview/parseConfiguredPreviewRefs.ts
+++ b/src/preview/parseConfiguredPreviewRefs.ts
@@ -1,6 +1,6 @@
 /**
- * Parses the configured preview refs (from `VITE_PLUS_PREVIEW_REFS` or the
- * runtime R2 refs index) that should be injected into packuments.
+ * Parses preview refs (registered at runtime in the R2 refs index) that should
+ * be injected into packuments.
  *
  * Only immutable commit refs are supported:
  *   commit.<sha>
@@ -64,14 +64,4 @@ export function parseConfiguredPreviewRefs(
     }
     return ref
   })
-}
-
-/** Lenient variant: drops invalid refs instead of throwing. */
-export function parseConfiguredPreviewRefsSafe(
-  input: string | undefined,
-): ParsedPreviewRef[] {
-  // Skip invalid config entries rather than failing the whole packument.
-  return splitRefs(input)
-    .map(parseSingleRef)
-    .filter((r): r is ParsedPreviewRef => r !== null)
 }

--- a/test/unit.test.ts
+++ b/test/unit.test.ts
@@ -5,7 +5,6 @@ import {
 } from '../src/preview/parsePreviewVersion'
 import {
   parseConfiguredPreviewRefs,
-  parseConfiguredPreviewRefsSafe,
   prNumberFromUrl,
 } from '../src/preview/parseConfiguredPreviewRefs'
 import { toPkgPrNewUrl } from '../src/preview/toPkgPrNewUrl'
@@ -88,16 +87,9 @@ describe('parseConfiguredPreviewRefs', () => {
     expect(parseConfiguredPreviewRefs(undefined)).toEqual([])
   })
 
-  it('rejects pr/invalid refs (strict throws, safe skips)', () => {
+  it('rejects pr/invalid refs (strict throws)', () => {
     expect(() => parseConfiguredPreviewRefs('bogus')).toThrow()
     expect(() => parseConfiguredPreviewRefs('pr.1891')).toThrow()
-    expect(parseConfiguredPreviewRefsSafe('pr.1,bogus,commit.abcdef0')).toEqual([
-      {
-        type: 'commit',
-        ref: 'abcdef0',
-        version: '0.0.0-commit.abcdef0',
-      },
-    ])
   })
 })
 

--- a/test/worker.test.ts
+++ b/test/worker.test.ts
@@ -1,5 +1,13 @@
 import { SELF } from 'cloudflare:test'
-import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest'
 import { createTarGzip, parseTarGzip } from 'nanotar'
 
 const BASE = 'https://bridge.example.com'
@@ -67,7 +75,7 @@ beforeAll(async () => {
     os: ['darwin'],
     cpu: ['arm64'],
   })
-  // The configured ref is `commit.a832a55` (see vitest.config.ts).
+  // The suite's fixture ref `commit.a832a55` (registered in beforeEach).
   const vitePlusCommit = await makeTarball({
     name: 'vite-plus',
     version: 'a832a55',
@@ -127,6 +135,20 @@ beforeAll(async () => {
 
 afterAll(() => {
   vi.unstubAllGlobals()
+})
+
+// The suite's fixture preview ref (`commit.a832a55`). It used to be injected via
+// the VITE_PLUS_PREVIEW_REFS env var; refs are now runtime-only, so register it
+// dynamically before each test (idempotent, so it survives storage isolation).
+beforeEach(async () => {
+  await SELF.fetch(`${BASE}/-/refs`, {
+    method: 'POST',
+    headers: {
+      authorization: 'Bearer test-admin-token',
+      'content-type': 'application/json',
+    },
+    body: JSON.stringify({ ref: 'commit.a832a55' }),
+  })
 })
 
 describe('packument endpoint', () => {
@@ -715,7 +737,7 @@ describe('admin: refs', () => {
     ).toBe(401)
   })
 
-  it('lists the env-configured refs without auth (public read)', async () => {
+  it('lists the registered refs without auth (public read)', async () => {
     const res = await SELF.fetch(`${BASE}/-/refs`)
     expect(res.status).toBe(200)
     const body = (await res.json()) as { refs: Array<{ ref: string }> }
@@ -894,7 +916,7 @@ describe('admin: refs', () => {
   })
 
   it('unregisters a ref', async () => {
-    // Use a sha that is not the env-configured ref, so removal is observable.
+    // Use a sha that is not the fixture ref, so removal is observable.
     const ref = 'commit.beefcafe'
     await SELF.fetch(`${BASE}/-/refs`, {
       method: 'POST',

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -9,7 +9,6 @@ export default defineConfig({
         // Test overrides for the bindings declared in wrangler.test.jsonc.
         bindings: {
           PUBLIC_BASE_URL: 'https://bridge.example.com',
-          VITE_PLUS_PREVIEW_REFS: 'commit.a832a55',
           ADMIN_TOKEN: 'test-admin-token',
         },
       },

--- a/wrangler.test.jsonc
+++ b/wrangler.test.jsonc
@@ -3,8 +3,7 @@
 // not auto-discover it; Void manages real bindings via `void.json` + inference.
 // `main` points at the assembled Hono app so the integration tests exercise the
 // same code the Void route layer forwards to. Host-specific vars
-// (PUBLIC_BASE_URL, VITE_PLUS_PREVIEW_REFS, ADMIN_TOKEN) are injected in
-// vitest.config.ts.
+// (PUBLIC_BASE_URL, ADMIN_TOKEN) are injected in vitest.config.ts.
 {
   "name": "pkg-pr-registry-bridge",
   "main": "src/app.ts",


### PR DESCRIPTION
Stacked on #37 (base `cache-packument-output`; retargets to `main` once #37 merges). Merge order: #37 → this.

## Why

Refs are registered dynamically now (the publish action calls `/-/refs` + `/-/publish` → R2 index), so the static `VITE_PLUS_PREVIEW_REFS` var is redundant for the actual preview flow. Its only remaining roles were a never-expiring default ref and a bootstrap for the deploy tooling, and neither needs a production config var.

## What

- **Production:** drop the var from `config.ts`/`env.ts`, drop the env-merge in `getConfiguredRefs` (now R2-only), and simplify the F5 output-cache key to `pkgt/<name>/<etag>` (the env-refs hash is gone). Removed the orphaned `parseConfiguredPreviewRefsSafe`.
- **Smoke test (the deploy gate):** no change needed beyond a comment , verified its checks don't depend on a registered ref (the packument check passes on npm's stable versions; download/HEAD resolve any sha without a registry lookup; `/-/refs` accepts an empty array).
- **e2e:** derives the ref to install from the live `/-/refs` instead of the env var (skips if the bridge lists none).
- **warm.mjs:** now a manual publish helper (`pnpm warm <sha>`); dropped from the `pnpm deploy` chain since there's nothing static to seed.
- **Tests:** the suite registers its fixture ref (`commit.a832a55`) dynamically in `beforeEach`.

## Verify

`tsc` clean, 76 tests pass, action bundle unaffected. Net −9 lines. The `rfcs/0001` design doc keeps its original references (historical record).