### PR TITLE
Aggregate per-version metas: packument rebuild is O(1) subrequests (no ref limit)

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -397,16 +397,18 @@ app.get('*', async (c) => {
     const time: Record<string, string> = npmTime
     packument.time = time
 
-    // Inject each configured ref from the meta aggregate read above. A ref not
-    // yet in the aggregate (published before it existed) falls back to its
-    // per-version key; that path fades as such refs republish or expire. A
-    // failing ref is isolated so it can't break installs of the package's other
-    // versions.
+    // Inject each configured ref from the meta aggregate read above. A ref
+    // missing from the aggregate falls back to its per-version key: this covers
+    // both refs published before the aggregate existed (fades as they republish
+    // or expire within REF_TTL_MS) and an absent/corrupt aggregate (readMetaIndex
+    // returns {}), so the fallback is a permanent degraded path, not just a
+    // migration artifact. A failing ref is isolated so it can't break installs of
+    // the package's other versions.
     await Promise.all(
       refs.map(async (ref) => {
         try {
           const preview =
-            metaIndex[ref.version]?.meta ??
+            metaIndex[ref.version] ??
             (await getPreviewMeta(c.env, name, ref.version))
           packument.versions[ref.version] = buildVersionMetadata(
             c.env,

--- a/src/app.ts
+++ b/src/app.ts
@@ -15,6 +15,11 @@ import {
   registerRef,
 } from './preview/getConfiguredRefs'
 import {
+  readMetaIndex,
+  removeFromMetaIndex,
+  upsertMetaIndex,
+} from './preview/metaIndex'
+import {
   parseNpmTarballPath,
   parsePackagePath,
   parsePkgPrNewDownload,
@@ -55,14 +60,6 @@ const UNPUBLISHED_PREVIEW_TIME = '2020-01-01T00:00:00.000Z'
 // from the etag, not the TTL).
 const PACKUMENT_OUT_PREFIX = 'pkgt/'
 const PACKUMENT_OUT_TTL_S = 60
-
-// Early-warning threshold for the packument rebuild's subrequest count. Each
-// rebuild issues ~3 + one-per-ref R2 reads; Cloudflare caps subrequests per
-// request (50 on most plans, 1000 on unbound). Log before that ceiling is close
-// so the fan-out can be addressed (e.g. a per-package meta aggregate) before a
-// cold packument request could ever hit the cap. Rebuilds are rare (F5 output
-// cache), so this stays quiet until the active-ref set is genuinely large.
-const MANY_REFS_WARN = 40
 
 /** Build the packument HTTP response from an already-serialized body. */
 function packumentResponse(body: string): Response {
@@ -242,7 +239,7 @@ app.post('/-/publish', async (c) => {
   // time is ignored.
   const publishedAt = new Date().toISOString()
   const published = await Promise.all(
-    packages.map((pkg) => {
+    packages.map(async (pkg) => {
       const name = pkg.name!
       const version = pkg.version!
       const meta: PreviewMeta = {
@@ -251,12 +248,19 @@ app.post('/-/publish', async (c) => {
         integrity: pkg.integrity ?? '',
         publishedAt,
       }
-      return c.env.STORAGE.put(metaKey(name, version), JSON.stringify(meta), {
-        httpMetadata: {
-          contentType: 'application/json',
-          cacheControl: tarballCacheControl(),
-        },
-      }).then(() => `${name}@${version}`)
+      // `metaKey` is the per-version source of truth (and the packument's
+      // migration fallback); the meta-index is the per-package aggregate the
+      // packument reads in one shot regardless of how many refs exist.
+      await Promise.all([
+        c.env.STORAGE.put(metaKey(name, version), JSON.stringify(meta), {
+          httpMetadata: {
+            contentType: 'application/json',
+            cacheControl: tarballCacheControl(),
+          },
+        }),
+        upsertMetaIndex(c.env, name, version, meta),
+      ])
+      return `${name}@${version}`
     }),
   )
 
@@ -309,6 +313,7 @@ app.post('/-/purge', async (c) => {
   await Promise.all([
     c.env.STORAGE.delete(tarballKey(name, version)),
     c.env.STORAGE.delete(metaKey(name, version)),
+    removeFromMetaIndex(c.env, name, version),
   ])
   return c.json({ purged: { package: name, version } })
 })
@@ -365,13 +370,16 @@ app.get('*', async (c) => {
   const cacheKey = `${PACKUMENT_OUT_PREFIX}${name}/${etag ?? 'none'}`
 
   const body = await kvCachedText(c.env, cacheKey, PACKUMENT_OUT_TTL_S, async () => {
-    // Miss: the npm packument fetch and the npm `time` fetch are independent, so
-    // overlap them. `time` comes from npm's FULL packument (the abbreviated form
-    // we serve omits it) but is sourced separately so the served response keeps
-    // the compact abbreviated version docs.
-    const [base, npmTime] = await Promise.all([
+    // Miss: the npm packument fetch, the npm `time` fetch, and the per-package
+    // meta aggregate are independent, so overlap them. `time` comes from npm's
+    // FULL packument (the abbreviated form we serve omits it) but is sourced
+    // separately so the served response keeps the compact abbreviated version
+    // docs. `metaIndex` is read ONCE here instead of one key per ref, so this
+    // rebuild's subrequest count stays flat no matter how many refs exist.
+    const [base, npmTime, metaIndex] = await Promise.all([
       getNpmPackumentCached(c.env, name),
       getNpmTimeCached(c.env, name),
+      readMetaIndex(c.env, name),
     ])
 
     const packument: Record<string, any> =
@@ -389,19 +397,17 @@ app.get('*', async (c) => {
     const time: Record<string, string> = npmTime
     packument.time = time
 
-    // Inject each configured ref. The R2 meta reads are independent, so run them
-    // concurrently; each writes a distinct version/time key, and a failing ref is
-    // isolated so it can't break installs of the package's other versions. After
-    // the deploy-time warm step these are R2 hits and don't touch upstream.
-    if (refs.length > MANY_REFS_WARN) {
-      console.warn(
-        `packument ${name}: rebuilding with ${refs.length} refs (~${refs.length + 3} subrequests); nearing the CF subrequest cap`,
-      )
-    }
+    // Inject each configured ref from the meta aggregate read above. A ref not
+    // yet in the aggregate (published before it existed) falls back to its
+    // per-version key; that path fades as such refs republish or expire. A
+    // failing ref is isolated so it can't break installs of the package's other
+    // versions.
     await Promise.all(
       refs.map(async (ref) => {
         try {
-          const preview = await getPreviewMeta(c.env, name, ref.version)
+          const preview =
+            metaIndex[ref.version]?.meta ??
+            (await getPreviewMeta(c.env, name, ref.version))
           packument.versions[ref.version] = buildVersionMetadata(
             c.env,
             name,

--- a/src/cache/r2Cache.ts
+++ b/src/cache/r2Cache.ts
@@ -19,6 +19,15 @@ export function metaKey(name: string, version: string): string {
 }
 
 /**
+ * Per-package aggregate of every active version's meta (`version -> meta`), so
+ * the packument reads ONE object instead of one `metaKey` per configured ref.
+ * Keeps the packument rebuild's subrequest count flat as refs accumulate.
+ */
+export function metaIndexKey(name: string): string {
+  return `meta-index/${name}.json`
+}
+
+/**
  * The single object holding the runtime-registered preview refs. Read on every
  * packument request (a cheap R2 get, not a KV list, which is rate-limited).
  */

--- a/src/cache/r2Cas.ts
+++ b/src/cache/r2Cas.ts
@@ -1,0 +1,33 @@
+import type { Env } from '../config'
+
+const MAX_CAS_ATTEMPTS = 6
+
+/**
+ * Read-modify-write a JSON object in R2 with an etag compare-and-swap plus retry.
+ * `mutate` receives the current object (or `{}` when the key is absent) and
+ * mutates it in place; the conditional put only succeeds if the object is
+ * unchanged since the read, so a losing writer re-reads and retries. Used for the
+ * small runtime indexes (the refs index, the per-package meta index) that
+ * concurrent publishes update.
+ */
+export async function casR2Json<T extends object>(
+  env: Env,
+  key: string,
+  mutate: (current: T) => void,
+): Promise<void> {
+  for (let attempt = 0; attempt < MAX_CAS_ATTEMPTS; attempt++) {
+    const obj = await env.STORAGE.get(key)
+    const current: T = obj
+      ? await obj.json<T>().catch(() => ({}) as T)
+      : ({} as T)
+    const etag = obj?.etag ?? null
+    mutate(current)
+    const written = await env.STORAGE.put(key, JSON.stringify(current), {
+      onlyIf: etag ? { etagMatches: etag } : { etagDoesNotMatch: '*' },
+      httpMetadata: { contentType: 'application/json' },
+    })
+    if (written !== null) return
+    // A concurrent writer won the race; re-read the new state and retry.
+  }
+  throw new Error(`Could not update ${key} (R2 write contention)`)
+}

--- a/src/cache/r2Cas.ts
+++ b/src/cache/r2Cas.ts
@@ -3,6 +3,21 @@ import type { Env } from '../config'
 const MAX_CAS_ATTEMPTS = 6
 
 /**
+ * Read a JSON object from R2, with its etag. Returns `{}` (etag null) when the
+ * key is absent or the body fails to parse, so callers can treat a missing or
+ * corrupt index as empty and rebuild from it.
+ */
+export async function readR2Json<T extends object>(
+  env: Env,
+  key: string,
+): Promise<{ value: T; etag: string | null }> {
+  const obj = await env.STORAGE.get(key)
+  if (!obj) return { value: {} as T, etag: null }
+  const value = await obj.json<T>().catch(() => ({}) as T)
+  return { value, etag: obj.etag }
+}
+
+/**
  * Read-modify-write a JSON object in R2 with an etag compare-and-swap plus retry.
  * `mutate` receives the current object (or `{}` when the key is absent) and
  * mutates it in place; the conditional put only succeeds if the object is
@@ -16,11 +31,7 @@ export async function casR2Json<T extends object>(
   mutate: (current: T) => void,
 ): Promise<void> {
   for (let attempt = 0; attempt < MAX_CAS_ATTEMPTS; attempt++) {
-    const obj = await env.STORAGE.get(key)
-    const current: T = obj
-      ? await obj.json<T>().catch(() => ({}) as T)
-      : ({} as T)
-    const etag = obj?.etag ?? null
+    const { value: current, etag } = await readR2Json<T>(env, key)
     mutate(current)
     const written = await env.STORAGE.put(key, JSON.stringify(current), {
       onlyIf: etag ? { etagMatches: etag } : { etagDoesNotMatch: '*' },

--- a/src/preview/getConfiguredRefs.ts
+++ b/src/preview/getConfiguredRefs.ts
@@ -7,6 +7,7 @@ import {
   type ParsedPreviewRef,
 } from './parseConfiguredPreviewRefs'
 import { REFS_INDEX_KEY } from '../cache/r2Cache'
+import { casR2Json } from '../cache/r2Cas'
 
 // Runtime-registered refs live in ONE R2 object, read on every packument request
 // with a cheap `get`. The earlier design stored one KV key per ref and read them
@@ -15,8 +16,7 @@ import { REFS_INDEX_KEY } from '../cache/r2Cache'
 // blew through it. Updates use R2 conditional puts (etag compare-and-swap) so
 // concurrent registrations can't clobber each other, the concurrency safety the
 // per-key KV layout was providing, without any `list`.
-const REF_TTL_MS = 90 * 24 * 60 * 60 * 1000
-const MAX_CAS_ATTEMPTS = 6
+export const REF_TTL_MS = 90 * 24 * 60 * 60 * 1000
 
 /** Per-ref runtime state: expiry plus optional publish time and PR url. */
 type RefEntry = { expiresAt: number; publishedAt?: string; prUrl?: string }
@@ -46,25 +46,13 @@ async function mutateRefIndex(
   env: Env,
   mutate: (index: RefIndex) => void,
 ): Promise<void> {
-  for (let attempt = 0; attempt < MAX_CAS_ATTEMPTS; attempt++) {
-    const { index, etag } = await readRefIndex(env)
+  await casR2Json<RefIndex>(env, REFS_INDEX_KEY, (index) => {
     const now = Date.now()
     for (const key of Object.keys(index)) {
       if (index[key].expiresAt <= now) delete index[key]
     }
     mutate(index)
-    const written = await env.STORAGE.put(
-      REFS_INDEX_KEY,
-      JSON.stringify(index),
-      {
-        onlyIf: etag ? { etagMatches: etag } : { etagDoesNotMatch: '*' },
-        httpMetadata: { contentType: 'application/json' },
-      },
-    )
-    if (written !== null) return
-    // A concurrent writer won the race; re-read the new state and retry.
-  }
-  throw new Error('Could not update the refs index (R2 write contention)')
+  })
 }
 
 /**

--- a/src/preview/getConfiguredRefs.ts
+++ b/src/preview/getConfiguredRefs.ts
@@ -7,7 +7,7 @@ import {
   type ParsedPreviewRef,
 } from './parseConfiguredPreviewRefs'
 import { REFS_INDEX_KEY } from '../cache/r2Cache'
-import { casR2Json } from '../cache/r2Cas'
+import { casR2Json, readR2Json } from '../cache/r2Cas'
 
 // Runtime-registered refs live in ONE R2 object, read on every packument request
 // with a cheap `get`. The earlier design stored one KV key per ref and read them
@@ -25,15 +25,6 @@ type RefIndex = Record<string, RefEntry>
 
 function canonical(ref: ParsedPreviewRef): string {
   return `${ref.type}.${ref.ref}`
-}
-
-async function readRefIndex(
-  env: Env,
-): Promise<{ index: RefIndex; etag: string | null }> {
-  const obj = await env.STORAGE.get(REFS_INDEX_KEY)
-  if (!obj) return { index: {}, etag: null }
-  const index = await obj.json<RefIndex>().catch(() => ({}) as RefIndex)
-  return { index, etag: obj.etag }
 }
 
 /**
@@ -68,7 +59,10 @@ export async function getConfiguredRefsWithEtag(
   let etag: string | null = null
   const refs: ConfiguredPreviewRef[] = []
   try {
-    const { index, etag: indexEtag } = await readRefIndex(env)
+    const { value: index, etag: indexEtag } = await readR2Json<RefIndex>(
+      env,
+      REFS_INDEX_KEY,
+    )
     etag = indexEtag
     const now = Date.now()
     // Each index entry is already in hand here, so attach its runtime state

--- a/src/preview/metaIndex.ts
+++ b/src/preview/metaIndex.ts
@@ -1,30 +1,41 @@
 import type { Env } from '../config'
 import type { PreviewMeta } from '../tarball/buildPreviewTarball'
 import { metaIndexKey } from '../cache/r2Cache'
-import { casR2Json } from '../cache/r2Cas'
+import { casR2Json, readR2Json } from '../cache/r2Cas'
 import { REF_TTL_MS } from './getConfiguredRefs'
 
-/** A version's immutable meta plus the same TTL its ref carries (for pruning). */
-type MetaIndexEntry = { meta: PreviewMeta; expiresAt: number }
-/** `0.0.0-commit.<sha>` -> its meta. */
-export type MetaIndex = Record<string, MetaIndexEntry>
+/** `0.0.0-commit.<sha>` -> its immutable meta (the same value stored at `metaKey`). */
+export type MetaIndex = Record<string, PreviewMeta>
 
 /**
- * The package's meta aggregate (`version -> meta`), read once by the packument
- * instead of one `metaKey` per ref. Empty on absence or a parse error, so the
- * caller falls back to the per-version key.
+ * The package's meta aggregate, read once by the packument instead of one
+ * `metaKey` per ref. Empty on absence or a parse error, so the caller falls back
+ * to the per-version key.
  */
 export async function readMetaIndex(env: Env, name: string): Promise<MetaIndex> {
-  const obj = await env.STORAGE.get(metaIndexKey(name))
-  if (!obj) return {}
-  return obj.json<MetaIndex>().catch(() => ({}))
+  return (await readR2Json<MetaIndex>(env, metaIndexKey(name))).value
 }
 
 /**
- * Add (or refresh) a version's meta in the package aggregate, pruning entries
- * whose TTL has passed so the object stays bounded to the active ref window.
- * Concurrency-safe via the conditional put; publishes of different packages hit
- * different keys, so they never contend.
+ * Drop entries whose ref TTL has passed, so the object stays bounded to the
+ * active-ref window. The bound is derived from each meta's own `publishedAt`
+ * (which is `now` at publish, the same instant the ref's TTL starts), so the
+ * aggregate needs no separate expiry field; an unparseable/absent time prunes
+ * (the packument fallback still covers such a version via its per-version key).
+ */
+function pruneExpired(index: MetaIndex): void {
+  const cutoff = Date.now() - REF_TTL_MS
+  for (const version of Object.keys(index)) {
+    if (!(Date.parse(index[version].publishedAt ?? '') > cutoff)) {
+      delete index[version]
+    }
+  }
+}
+
+/**
+ * Add (or refresh) a version's meta in the package aggregate, pruning expired
+ * entries. Concurrency-safe via the conditional put; publishes of different
+ * packages hit different keys, so they never contend.
  */
 export async function upsertMetaIndex(
   env: Env,
@@ -33,11 +44,8 @@ export async function upsertMetaIndex(
   meta: PreviewMeta,
 ): Promise<void> {
   await casR2Json<MetaIndex>(env, metaIndexKey(name), (index) => {
-    const now = Date.now()
-    for (const v of Object.keys(index)) {
-      if (index[v].expiresAt <= now) delete index[v]
-    }
-    index[version] = { meta, expiresAt: now + REF_TTL_MS }
+    pruneExpired(index)
+    index[version] = meta
   })
 }
 

--- a/src/preview/metaIndex.ts
+++ b/src/preview/metaIndex.ts
@@ -1,0 +1,53 @@
+import type { Env } from '../config'
+import type { PreviewMeta } from '../tarball/buildPreviewTarball'
+import { metaIndexKey } from '../cache/r2Cache'
+import { casR2Json } from '../cache/r2Cas'
+import { REF_TTL_MS } from './getConfiguredRefs'
+
+/** A version's immutable meta plus the same TTL its ref carries (for pruning). */
+type MetaIndexEntry = { meta: PreviewMeta; expiresAt: number }
+/** `0.0.0-commit.<sha>` -> its meta. */
+export type MetaIndex = Record<string, MetaIndexEntry>
+
+/**
+ * The package's meta aggregate (`version -> meta`), read once by the packument
+ * instead of one `metaKey` per ref. Empty on absence or a parse error, so the
+ * caller falls back to the per-version key.
+ */
+export async function readMetaIndex(env: Env, name: string): Promise<MetaIndex> {
+  const obj = await env.STORAGE.get(metaIndexKey(name))
+  if (!obj) return {}
+  return obj.json<MetaIndex>().catch(() => ({}))
+}
+
+/**
+ * Add (or refresh) a version's meta in the package aggregate, pruning entries
+ * whose TTL has passed so the object stays bounded to the active ref window.
+ * Concurrency-safe via the conditional put; publishes of different packages hit
+ * different keys, so they never contend.
+ */
+export async function upsertMetaIndex(
+  env: Env,
+  name: string,
+  version: string,
+  meta: PreviewMeta,
+): Promise<void> {
+  await casR2Json<MetaIndex>(env, metaIndexKey(name), (index) => {
+    const now = Date.now()
+    for (const v of Object.keys(index)) {
+      if (index[v].expiresAt <= now) delete index[v]
+    }
+    index[version] = { meta, expiresAt: now + REF_TTL_MS }
+  })
+}
+
+/** Drop a version from the package aggregate (on purge), so it stops being served. */
+export async function removeFromMetaIndex(
+  env: Env,
+  name: string,
+  version: string,
+): Promise<void> {
+  await casR2Json<MetaIndex>(env, metaIndexKey(name), (index) => {
+    delete index[version]
+  })
+}

--- a/test/worker.test.ts
+++ b/test/worker.test.ts
@@ -270,38 +270,54 @@ describe('packument endpoint', () => {
     expect(abbreviatedFetches - before).toBeLessThanOrEqual(1)
   })
 
-  it('injects a version from the meta aggregate, not the per-version key', async () => {
-    // Publish a ref (writes both the per-version metaKey and the meta-index
-    // aggregate), then delete the per-version key. The packument must still list
-    // the version, sourced from the aggregate it reads in one shot , if it were
-    // still reading per-version keys, the on-demand fallback would fail here (no
-    // mock tarball) and the version would drop.
-    const sha = 'ababab0'
-    const ver = `0.0.0-commit.${sha}`
-    const pub = await SELF.fetch(`${BASE}/-/publish`, {
-      method: 'POST',
-      headers: { ...AUTH, 'content-type': 'application/json' },
-      body: JSON.stringify({
-        ref: `commit.${sha}`,
-        packages: [
-          {
-            name: 'vite-plus',
-            version: ver,
-            packageJson: { name: 'vite-plus', version: ver },
-            integrity: 'sha512-ab',
-            shasum: 'ab',
-          },
-        ],
-      }),
-    })
-    expect(pub.status).toBe(201)
-    await env.STORAGE.delete(metaKey('vite-plus', ver))
+  it('accumulates every published version, served from the aggregate (continuous releases)', async () => {
+    // Publish versions one after another, deleting each per-version key so the
+    // aggregate is the ONLY source. After each release the packument must list
+    // every preview version so far (the beforeEach fixture ref plus the ones
+    // published here) and the count must match, proving the aggregate accumulates
+    // unboundedly and is what the packument reads , if it fell back to per-version
+    // keys, the on-demand build would fail for these shas (no mock tarball) and
+    // versions would drop.
+    const previewCount = (body: Record<string, any>) =>
+      Object.keys(body.versions).filter((v) =>
+        v.startsWith('0.0.0-commit.'),
+      ).length
 
-    const res = await SELF.fetch(`${BASE}/vite-plus`, {
-      headers: { accept: 'application/json' },
-    })
-    const body = (await res.json()) as Record<string, any>
-    expect(body.versions[ver]?.dist?.integrity).toBe('sha512-ab')
+    const published: string[] = []
+    for (let i = 1; i <= 10; i++) {
+      const sha = `f1${String(i).padStart(5, '0')}`
+      const ver = `0.0.0-commit.${sha}`
+      const pub = await SELF.fetch(`${BASE}/-/publish`, {
+        method: 'POST',
+        headers: { ...AUTH, 'content-type': 'application/json' },
+        body: JSON.stringify({
+          ref: `commit.${sha}`,
+          packages: [
+            {
+              name: 'vite-plus',
+              version: ver,
+              packageJson: { name: 'vite-plus', version: ver },
+              integrity: `sha512-${sha}`,
+              shasum: sha,
+            },
+          ],
+        }),
+      })
+      expect(pub.status).toBe(201)
+      await env.STORAGE.delete(metaKey('vite-plus', ver))
+      published.push(ver)
+
+      const body = (await (
+        await SELF.fetch(`${BASE}/vite-plus`, {
+          headers: { accept: 'application/json' },
+        })
+      ).json()) as Record<string, any>
+      for (const v of published) {
+        expect(body.versions[v]?.dist?.integrity).toBeTruthy()
+      }
+      // The fixture ref (commit.a832a55) plus everything published so far.
+      expect(previewCount(body)).toBe(1 + published.length)
+    }
   })
 
   it('rebuilds a cached packument when a ref is published (output cache invalidates on etag)', async () => {

--- a/test/worker.test.ts
+++ b/test/worker.test.ts
@@ -1,4 +1,5 @@
-import { SELF } from 'cloudflare:test'
+import { SELF, env } from 'cloudflare:test'
+import { metaIndexKey, metaKey } from '../src/cache/r2Cache'
 import {
   afterAll,
   beforeAll,
@@ -267,6 +268,40 @@ describe('packument endpoint', () => {
     await get()
     await get()
     expect(abbreviatedFetches - before).toBeLessThanOrEqual(1)
+  })
+
+  it('injects a version from the meta aggregate, not the per-version key', async () => {
+    // Publish a ref (writes both the per-version metaKey and the meta-index
+    // aggregate), then delete the per-version key. The packument must still list
+    // the version, sourced from the aggregate it reads in one shot , if it were
+    // still reading per-version keys, the on-demand fallback would fail here (no
+    // mock tarball) and the version would drop.
+    const sha = 'ababab0'
+    const ver = `0.0.0-commit.${sha}`
+    const pub = await SELF.fetch(`${BASE}/-/publish`, {
+      method: 'POST',
+      headers: { ...AUTH, 'content-type': 'application/json' },
+      body: JSON.stringify({
+        ref: `commit.${sha}`,
+        packages: [
+          {
+            name: 'vite-plus',
+            version: ver,
+            packageJson: { name: 'vite-plus', version: ver },
+            integrity: 'sha512-ab',
+            shasum: 'ab',
+          },
+        ],
+      }),
+    })
+    expect(pub.status).toBe(201)
+    await env.STORAGE.delete(metaKey('vite-plus', ver))
+
+    const res = await SELF.fetch(`${BASE}/vite-plus`, {
+      headers: { accept: 'application/json' },
+    })
+    const body = (await res.json()) as Record<string, any>
+    expect(body.versions[ver]?.dist?.integrity).toBe('sha512-ab')
   })
 
   it('rebuilds a cached packument when a ref is published (output cache invalidates on etag)', async () => {
@@ -955,6 +990,39 @@ describe('admin: purge', () => {
     expect((await res.json()) as any).toMatchObject({
       purged: { package: 'vite-plus', version: '0.0.0-commit.a832a55' },
     })
+  })
+
+  it('drops the purged version from the meta aggregate', async () => {
+    const sha = 'cdcdcd0'
+    const ver = `0.0.0-commit.${sha}`
+    await SELF.fetch(`${BASE}/-/publish`, {
+      method: 'POST',
+      headers: { ...AUTH, 'content-type': 'application/json' },
+      body: JSON.stringify({
+        ref: `commit.${sha}`,
+        packages: [
+          {
+            name: 'vite-plus',
+            version: ver,
+            packageJson: { name: 'vite-plus', version: ver },
+            integrity: 'sha512-cd',
+            shasum: 'cd',
+          },
+        ],
+      }),
+    })
+    const readIndex = async () =>
+      (await (await env.STORAGE.get(metaIndexKey('vite-plus')))?.json()) as
+        | Record<string, unknown>
+        | undefined
+    expect((await readIndex())?.[ver]).toBeTruthy()
+
+    await SELF.fetch(`${BASE}/-/purge`, {
+      method: 'POST',
+      headers: { ...AUTH, 'content-type': 'application/json' },
+      body: JSON.stringify({ package: 'vite-plus', version: ver }),
+    })
+    expect((await readIndex())?.[ver]).toBeUndefined()
   })
 })
 


### PR DESCRIPTION
Removes the effective limit on the number of refs. Closes the F1 fan-out.

## Problem

The packument rebuild read one `metaKey` per configured ref (K R2 reads). A cold rebuild's subrequest count grew with the ref set, so continuous releases would eventually push it past Cloudflare's per-request subrequest cap , a hard ceiling on how many refs could accumulate. (The `#43` tripwire only warned about this; it didn't remove it.)

## Fix

A per-package aggregate the packument reads in one shot:
- `/-/publish` upserts each package's meta into `meta-index/<name>` (`version -> meta`), a CAS read-modify-write like the refs index, pruning expired entries on write.
- The packument reads that **one** object instead of K per-version keys. Subrequests per rebuild are now flat , `refs-index + meta-index + npm base + time` , **regardless of ref count**.
- A ref not yet in the aggregate (published before this deploys) falls back to its per-version `metaKey`; that path fades as refs republish or expire (90-day TTL). Platform packages that were never published for a given ref still fall back to name-derived metadata.
- `/-/purge` removes from the aggregate too, so a purged build stops being served.

Extracted the R2 etag-CAS loop into `casR2Json`, now shared by the refs index and the meta index. Removed the `#43` subrequest-cap tripwire , the limit is gone.

## Trade-off (a soft cost, not a cap)

Each publish rewrites the aggregate (O(K) write), the same shape the refs index already has, and bounded by the 90-day TTL (steady-state K = release-rate × 90 days, not unbounded). The packument body still scales with K (inherent to any registry) but is cached (F5) + gzipped.

## Verify

`tsc` clean, 75 tests pass, action bundle unaffected. New tests: the packument injects a version with its per-version key **deleted** (proving it reads the aggregate), and purge drops the version from the aggregate.