### PR TITLE
Renovate: honor pnpm's minimum-release-age and flag bundle-affecting deps

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,10 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended"
-  ]
+  ],
+  "description": [
+    "minimumReleaseAge keeps Renovate from proposing a version newer than pnpm's minimum-release-age cooldown. pnpm 11 enforces a 1-day supply-chain policy on `pnpm install --frozen-lockfile`, so a same-day bump writes a too-new lockfile entry and CI fails with ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION. 3 days clears the 1-day floor with margin. internalChecksFilter=strict holds such an update until it ages in, instead of opening a red PR."
+  ],
+  "minimumReleaseAge": "3 days",
+  "internalChecksFilter": "strict"
 }

--- a/renovate.json
+++ b/renovate.json
@@ -7,5 +7,22 @@
     "minimumReleaseAge keeps Renovate from proposing a version newer than pnpm's minimum-release-age cooldown. pnpm 11 enforces a 1-day supply-chain policy on `pnpm install --frozen-lockfile`, so a same-day bump writes a too-new lockfile entry and CI fails with ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION. 3 days clears the 1-day floor with margin. internalChecksFilter=strict holds such an update until it ages in, instead of opening a red PR."
   ],
   "minimumReleaseAge": "3 days",
-  "internalChecksFilter": "strict"
+  "internalChecksFilter": "strict",
+  "packageRules": [
+    {
+      "description": [
+        "nanotar (bundled) and esbuild (the bundler) are compiled into the committed publish-action bundle (.github/actions/publish-preview/dist), which CI rebuilds and diff-checks. A bump to either needs `pnpm build:action` re-run and the dist re-committed, so flag those PRs; the 'Verify action bundle' CI check is the backstop for anything else."
+      ],
+      "matchPackageNames": [
+        "nanotar",
+        "esbuild"
+      ],
+      "addLabels": [
+        "needs-bundle-rebuild"
+      ],
+      "prBodyNotes": [
+        "⚠️ This dependency is compiled into the committed publish-action bundle. Run `pnpm build:action` and commit `.github/actions/publish-preview/dist` on this branch, or the \"Verify action bundle\" CI check will fail."
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
Two Renovate config hardenings (same file).

## 1. Wait out pnpm's minimum-release-age cooldown

Renovate PRs like #40 fail CI at `pnpm install --frozen-lockfile`:

```
[ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION] wrangler@4.106.0 was published ... within the minimumReleaseAge cutoff
```

pnpm 11 enforces a 1-day supply-chain cooldown, but Renovate (`config:recommended`) proposes bumps the same day a version publishes, so the lockfile entry is too new and the PR is dead on arrival.

- **`minimumReleaseAge: "3 days"`** , clears pnpm's 1-day floor with margin.
- **`internalChecksFilter: "strict"`** , holds a too-new update instead of opening a red PR.

## 2. Flag deps compiled into the committed bundle

`.github/actions/publish-preview/dist` is a committed artifact an external repo consumes by ref, so it must stay fresh. Only **nanotar** (bundled) and **esbuild** (the bundler) stale it. Renovate can't rebuild it here (Mend-hosted, no push token), so a `packageRule` adds a `needs-bundle-rebuild` label + a PR note telling the author to run `pnpm build:action` and commit the dist. CI's "Verify action bundle" check stays the backstop for anything else.

Config-only; no lockfile touched, so this PR's own CI is unaffected.