### PR TITLE
Reduce per-request CPU/memory in workspace-package check and tarball fetch

### DIFF
--- a/.github/actions/publish-preview/dist/index.mjs
+++ b/.github/actions/publish-preview/dist/index.mjs
@@ -328,6 +328,12 @@ var HttpError = class extends Error {
   }
 };
 
+// src/util/splitCsv.ts
+function splitCsv(input2) {
+  if (!input2) return [];
+  return input2.split(",").map((s) => s.trim()).filter(Boolean);
+}
+
 // src/preview/packages.ts
 var PREVIEW_PACKAGES = /* @__PURE__ */ new Set([
   "@voidzero-dev/vite-plus-core",
@@ -336,8 +342,15 @@ var PREVIEW_PACKAGES = /* @__PURE__ */ new Set([
 function isPreviewPackage(name) {
   return PREVIEW_PACKAGES.has(name);
 }
+var patternsMemo;
+function workspacePatterns(raw) {
+  if (patternsMemo?.raw !== raw) {
+    patternsMemo = { raw, patterns: splitCsv(raw) };
+  }
+  return patternsMemo.patterns;
+}
 function isWorkspacePackage(name, env) {
-  const patterns = (env.WORKSPACE_PACKAGES ?? "").split(",").map((s) => s.trim()).filter(Boolean);
+  const patterns = workspacePatterns(env.WORKSPACE_PACKAGES ?? "");
   if (patterns.length === 0) return PREVIEW_PACKAGES.has(name);
   for (const pattern of patterns) {
     if (pattern.endsWith("*")) {
@@ -506,12 +519,8 @@ function parseSingleRef(value) {
     version: commitVersion(commit[1])
   };
 }
-function splitRefs(input2) {
-  if (!input2) return [];
-  return input2.split(",").map((s) => s.trim()).filter(Boolean);
-}
 function parseConfiguredPreviewRefs(input2) {
-  return splitRefs(input2).map((value) => {
+  return splitCsv(input2).map((value) => {
     const ref = parseSingleRef(value);
     if (!ref) {
       throw new Error(

--- a/src/preview/packages.ts
+++ b/src/preview/packages.ts
@@ -1,3 +1,5 @@
+import { splitCsv } from '../util/splitCsv'
+
 /**
  * Strict allowlist of packages that may receive synthetic preview versions.
  * Everything else is proxied to npm unchanged. The bridge must never become a
@@ -10,6 +12,20 @@ export const PREVIEW_PACKAGES = new Set<string>([
 
 export function isPreviewPackage(name: string): boolean {
   return PREVIEW_PACKAGES.has(name)
+}
+
+// `WORKSPACE_PACKAGES` is a static Worker var: constant for the isolate's
+// lifetime, but `isWorkspacePackage` is called multiple times per request. A
+// single-entry memo (keyed by the raw string) skips the split/trim/filter
+// allocation on every call while still handling the differing configs each
+// test in this suite passes.
+let patternsMemo: { raw: string; patterns: string[] } | undefined
+
+function workspacePatterns(raw: string): string[] {
+  if (patternsMemo?.raw !== raw) {
+    patternsMemo = { raw, patterns: splitCsv(raw) }
+  }
+  return patternsMemo.patterns
 }
 
 /**
@@ -27,10 +43,7 @@ export function isWorkspacePackage(
   name: string,
   env: { WORKSPACE_PACKAGES?: string },
 ): boolean {
-  const patterns = (env.WORKSPACE_PACKAGES ?? '')
-    .split(',')
-    .map((s) => s.trim())
-    .filter(Boolean)
+  const patterns = workspacePatterns(env.WORKSPACE_PACKAGES ?? '')
 
   // Safe fallback if unconfigured: only the synthetic-version packages.
   if (patterns.length === 0) return PREVIEW_PACKAGES.has(name)

--- a/src/preview/parseConfiguredPreviewRefs.ts
+++ b/src/preview/parseConfiguredPreviewRefs.ts
@@ -9,6 +9,7 @@
  * would be overwritten as the PR advances.
  */
 import { commitVersion } from './parsePreviewVersion'
+import { splitCsv } from '../util/splitCsv'
 
 /** A ref as produced by parsing alone, with no runtime state. */
 export type ParsedPreviewRef = {
@@ -43,19 +44,11 @@ export function parseSingleRef(value: string): ParsedPreviewRef | null {
   }
 }
 
-function splitRefs(input: string | undefined): string[] {
-  if (!input) return []
-  return input
-    .split(',')
-    .map((s) => s.trim())
-    .filter(Boolean)
-}
-
 /** Strict parser: throws on an invalid or non-commit ref. */
 export function parseConfiguredPreviewRefs(
   input: string | undefined,
 ): ParsedPreviewRef[] {
-  return splitRefs(input).map((value) => {
+  return splitCsv(input).map((value) => {
     const ref = parseSingleRef(value)
     if (!ref) {
       throw new Error(

--- a/src/tarball/fetchUpstreamTarball.ts
+++ b/src/tarball/fetchUpstreamTarball.ts
@@ -1,8 +1,5 @@
 import { HttpError } from '../httpError'
 
-/** Initial buffer capacity when the upstream doesn't declare a usable size. */
-const DEFAULT_INITIAL_CAPACITY = 64 * 1024
-
 async function fetchUpstream(
   url: string,
   maxBytes: number,
@@ -33,20 +30,18 @@ async function fetchUpstream(
   return { body: res.body, declaredLength: declared }
 }
 
+/** Cancel the reader and reject for exceeding `maxBytes`. Never returns. */
+async function rejectOversized(
+  reader: ReadableStreamDefaultReader<Uint8Array>,
+): Promise<never> {
+  await reader.cancel()
+  throw new HttpError(413, 'Upstream tarball exceeds the maximum size')
+}
+
 /**
  * Download an upstream pkg.pr.new tarball into memory, enforcing a maximum size
  * while streaming so a malicious or oversized upstream cannot exhaust the
  * Worker.
- *
- * Pre-sizes the buffer from `Content-Length` when the upstream declares one
- * (the common case), so a fully-filled download streams straight into one
- * buffer with no extra copy at the end. `Content-Length` is only a sizing
- * HINT here, never a hard cap: the limit actually enforced is always
- * `maxBytes`, so an upstream that under-reports its own size (a re-chunking
- * proxy, an off-by-a-few-bytes header) still downloads successfully instead of
- * failing with a spurious "too large". A wrong guess just grows the buffer
- * (capped at `maxBytes`), the same bound the no-declared-length case starts
- * from.
  */
 export async function fetchUpstreamTarball(
   url: string,
@@ -55,25 +50,59 @@ export async function fetchUpstreamTarball(
   const { body, declaredLength } = await fetchUpstream(url, maxBytes)
   const reader = body.getReader()
 
-  let out = new Uint8Array(
-    Math.min(declaredLength ?? DEFAULT_INITIAL_CAPACITY, maxBytes),
-  )
-  let offset = 0
+  // `Content-Length` is a sizing HINT, never a hard cap: the limit actually
+  // enforced is always `maxBytes`. Pre-size the buffer to it so a correctly
+  // reported download (the common case) streams straight into one buffer with
+  // no extra copy at the end; an upstream that under-reports its own size (a
+  // re-chunking proxy, an off-by-a-few-bytes header) just grows the buffer
+  // rather than failing with a spurious "too large". Growth here is expected
+  // to be a small correction to a mostly-right guess, so doubling from that
+  // guess (rather than the unbounded doubling-from-nothing below) doesn't
+  // meaningfully overshoot the actual size.
+  if (declaredLength !== null) {
+    let out = new Uint8Array(declaredLength)
+    let offset = 0
+    for (;;) {
+      const { done, value } = await reader.read()
+      if (done) break
+      const end = offset + value.byteLength
+      if (end > maxBytes) {
+        return rejectOversized(reader)
+      }
+      if (end > out.length) {
+        const grown = new Uint8Array(Math.min(maxBytes, Math.max(out.length * 2, end)))
+        grown.set(out.subarray(0, offset))
+        out = grown
+      }
+      out.set(value, offset)
+      offset = end
+    }
+    return offset === out.length ? out : out.slice(0, offset)
+  }
+
+  // No usable size hint at all: collect chunks as-is (no reallocation while
+  // streaming) and copy them into one exactly-sized buffer at the end, so
+  // peak memory tracks the actual body size instead of a doubling sequence
+  // that can land far above it (e.g. an unknown-length body just over half of
+  // `maxBytes` would otherwise grow all the way to the `maxBytes` cap before
+  // being sliced back down).
+  const chunks: Uint8Array[] = []
+  let total = 0
   for (;;) {
     const { done, value } = await reader.read()
     if (done) break
-    const end = offset + value.byteLength
-    if (end > maxBytes) {
-      await reader.cancel()
-      throw new HttpError(413, 'Upstream tarball exceeds the maximum size')
+    total += value.byteLength
+    if (total > maxBytes) {
+      return rejectOversized(reader)
     }
-    if (end > out.length) {
-      const grown = new Uint8Array(Math.min(maxBytes, Math.max(out.length * 2, end)))
-      grown.set(out.subarray(0, offset))
-      out = grown
-    }
-    out.set(value, offset)
-    offset = end
+    chunks.push(value)
   }
-  return offset === out.length ? out : out.slice(0, offset)
+
+  const out = new Uint8Array(total)
+  let offset = 0
+  for (const chunk of chunks) {
+    out.set(chunk, offset)
+    offset += chunk.byteLength
+  }
+  return out
 }

--- a/src/tarball/fetchUpstreamTarball.ts
+++ b/src/tarball/fetchUpstreamTarball.ts
@@ -1,5 +1,8 @@
 import { HttpError } from '../httpError'
 
+/** Initial buffer capacity when the upstream doesn't declare a usable size. */
+const DEFAULT_INITIAL_CAPACITY = 64 * 1024
+
 async function fetchUpstream(
   url: string,
   maxBytes: number,
@@ -19,27 +22,31 @@ async function fetchUpstream(
     throw new HttpError(502, `Failed to fetch upstream tarball (${res.status})`)
   }
 
+  // Only a well-formed non-negative integer counts as declared: anything else
+  // (absent, blank, fractional, non-numeric) is treated as unknown, rather
+  // than coerced by `Number(...)` (which turns `''` into `0`, not `NaN`).
   const header = res.headers.get('content-length')
-  const declared = header !== null ? Number(header) : NaN
-  const valid = Number.isFinite(declared) && declared >= 0
-  if (valid && declared > maxBytes) {
+  const declared = header !== null && /^\d+$/.test(header) ? Number(header) : null
+  if (declared !== null && declared > maxBytes) {
     throw new HttpError(413, 'Upstream tarball exceeds the maximum size')
   }
-  return { body: res.body, declaredLength: valid ? declared : null }
-}
-
-/** Cancel the reader and reject for exceeding `maxBytes`. Never returns. */
-async function rejectOversized(
-  reader: ReadableStreamDefaultReader<Uint8Array>,
-): Promise<never> {
-  await reader.cancel()
-  throw new HttpError(413, 'Upstream tarball exceeds the maximum size')
+  return { body: res.body, declaredLength: declared }
 }
 
 /**
  * Download an upstream pkg.pr.new tarball into memory, enforcing a maximum size
  * while streaming so a malicious or oversized upstream cannot exhaust the
  * Worker.
+ *
+ * Pre-sizes the buffer from `Content-Length` when the upstream declares one
+ * (the common case), so a fully-filled download streams straight into one
+ * buffer with no extra copy at the end. `Content-Length` is only a sizing
+ * HINT here, never a hard cap: the limit actually enforced is always
+ * `maxBytes`, so an upstream that under-reports its own size (a re-chunking
+ * proxy, an off-by-a-few-bytes header) still downloads successfully instead of
+ * failing with a spurious "too large". A wrong guess just grows the buffer
+ * (capped at `maxBytes`), the same bound the no-declared-length case starts
+ * from.
  */
 export async function fetchUpstreamTarball(
   url: string,
@@ -48,46 +55,25 @@ export async function fetchUpstreamTarball(
   const { body, declaredLength } = await fetchUpstream(url, maxBytes)
   const reader = body.getReader()
 
-  // `Content-Length` is already known (and within bounds) here, so stream
-  // straight into one pre-sized buffer instead of collecting per-chunk arrays
-  // and copying them all into a second, final buffer (halves peak memory for
-  // this, the common, case).
-  if (declaredLength !== null) {
-    const out = new Uint8Array(declaredLength)
-    let offset = 0
-    for (;;) {
-      const { done, value } = await reader.read()
-      if (done) break
-      if (offset + value.byteLength > declaredLength) {
-        return rejectOversized(reader)
-      }
-      out.set(value, offset)
-      offset += value.byteLength
-    }
-    // A short read (fewer bytes than declared) copies down to the actual
-    // size, so the oversized backing buffer can be GC'd instead of kept alive
-    // by a `subarray` view over it; the common, fully-filled case above
-    // returns `out` itself with no extra copy.
-    return offset === declaredLength ? out : out.slice(0, offset)
-  }
-
-  const chunks: Uint8Array[] = []
-  let total = 0
+  let out = new Uint8Array(
+    Math.min(declaredLength ?? DEFAULT_INITIAL_CAPACITY, maxBytes),
+  )
+  let offset = 0
   for (;;) {
     const { done, value } = await reader.read()
     if (done) break
-    total += value.byteLength
-    if (total > maxBytes) {
-      return rejectOversized(reader)
+    const end = offset + value.byteLength
+    if (end > maxBytes) {
+      await reader.cancel()
+      throw new HttpError(413, 'Upstream tarball exceeds the maximum size')
     }
-    chunks.push(value)
+    if (end > out.length) {
+      const grown = new Uint8Array(Math.min(maxBytes, Math.max(out.length * 2, end)))
+      grown.set(out.subarray(0, offset))
+      out = grown
+    }
+    out.set(value, offset)
+    offset = end
   }
-
-  const out = new Uint8Array(total)
-  let offset = 0
-  for (const chunk of chunks) {
-    out.set(chunk, offset)
-    offset += chunk.byteLength
-  }
-  return out
+  return offset === out.length ? out : out.slice(0, offset)
 }

--- a/src/tarball/fetchUpstreamTarball.ts
+++ b/src/tarball/fetchUpstreamTarball.ts
@@ -1,6 +1,9 @@
 import { HttpError } from '../httpError'
 
-async function fetchUpstream(url: string, maxBytes: number) {
+async function fetchUpstream(
+  url: string,
+  maxBytes: number,
+): Promise<{ body: ReadableStream<Uint8Array>; declaredLength: number | null }> {
   const res = await fetch(url, {
     headers: {
       accept: 'application/octet-stream',
@@ -16,11 +19,21 @@ async function fetchUpstream(url: string, maxBytes: number) {
     throw new HttpError(502, `Failed to fetch upstream tarball (${res.status})`)
   }
 
-  const declared = Number(res.headers.get('content-length') ?? '')
-  if (Number.isFinite(declared) && declared > maxBytes) {
+  const header = res.headers.get('content-length')
+  const declared = header !== null ? Number(header) : NaN
+  const valid = Number.isFinite(declared) && declared >= 0
+  if (valid && declared > maxBytes) {
     throw new HttpError(413, 'Upstream tarball exceeds the maximum size')
   }
-  return res.body
+  return { body: res.body, declaredLength: valid ? declared : null }
+}
+
+/** Cancel the reader and reject for exceeding `maxBytes`. Never returns. */
+async function rejectOversized(
+  reader: ReadableStreamDefaultReader<Uint8Array>,
+): Promise<never> {
+  await reader.cancel()
+  throw new HttpError(413, 'Upstream tarball exceeds the maximum size')
 }
 
 /**
@@ -32,9 +45,32 @@ export async function fetchUpstreamTarball(
   url: string,
   maxBytes: number,
 ): Promise<Uint8Array> {
-  const body = await fetchUpstream(url, maxBytes)
-
+  const { body, declaredLength } = await fetchUpstream(url, maxBytes)
   const reader = body.getReader()
+
+  // `Content-Length` is already known (and within bounds) here, so stream
+  // straight into one pre-sized buffer instead of collecting per-chunk arrays
+  // and copying them all into a second, final buffer (halves peak memory for
+  // this, the common, case).
+  if (declaredLength !== null) {
+    const out = new Uint8Array(declaredLength)
+    let offset = 0
+    for (;;) {
+      const { done, value } = await reader.read()
+      if (done) break
+      if (offset + value.byteLength > declaredLength) {
+        return rejectOversized(reader)
+      }
+      out.set(value, offset)
+      offset += value.byteLength
+    }
+    // A short read (fewer bytes than declared) copies down to the actual
+    // size, so the oversized backing buffer can be GC'd instead of kept alive
+    // by a `subarray` view over it; the common, fully-filled case above
+    // returns `out` itself with no extra copy.
+    return offset === declaredLength ? out : out.slice(0, offset)
+  }
+
   const chunks: Uint8Array[] = []
   let total = 0
   for (;;) {
@@ -42,8 +78,7 @@ export async function fetchUpstreamTarball(
     if (done) break
     total += value.byteLength
     if (total > maxBytes) {
-      await reader.cancel()
-      throw new HttpError(413, 'Upstream tarball exceeds the maximum size')
+      return rejectOversized(reader)
     }
     chunks.push(value)
   }

--- a/src/util/splitCsv.ts
+++ b/src/util/splitCsv.ts
@@ -1,0 +1,8 @@
+/** Split a comma-separated string into trimmed, non-empty tokens. */
+export function splitCsv(input: string | undefined): string[] {
+  if (!input) return []
+  return input
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean)
+}

--- a/test/unit.test.ts
+++ b/test/unit.test.ts
@@ -406,6 +406,13 @@ describe('fetchUpstreamTarball', () => {
     expect(Array.from(out)).toEqual([9, 8, 7, 6])
   })
 
+  it('assembles a larger multi-chunk body with no Content-Length', async () => {
+    const big = new Uint8Array(100_000).map((_, i) => i % 256)
+    mockUpstream([big.slice(0, 60_000), big.slice(60_000)])
+    const out = await fetchUpstreamTarball('https://example.com/t.tgz', 200_000)
+    expect(out).toEqual(big)
+  })
+
   it('rejects a declared Content-Length over the max', async () => {
     mockUpstream([new Uint8Array([1])], { 'content-length': '2000' })
     await expectTooLarge(fetchUpstreamTarball('https://example.com/t.tgz', 1024))

--- a/test/unit.test.ts
+++ b/test/unit.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
   isPreviewVersion,
   parsePreviewVersion,
@@ -25,6 +25,8 @@ import {
 } from '../src/security/validateTarballPath'
 import { buildVersionMetadata } from '../src/registry/buildVersionMetadata'
 import { computeDigests } from '../src/tarball/digests'
+import { fetchUpstreamTarball } from '../src/tarball/fetchUpstreamTarball'
+import { HttpError } from '../src/httpError'
 import type { Env } from '../src/config'
 
 const env = {
@@ -358,5 +360,64 @@ describe('computeDigests', () => {
     expect(d.integrity).toMatch(/^sha512-[A-Za-z0-9+/]+=*$/)
     const again = await computeDigests(data)
     expect(again.integrity).toBe(d.integrity)
+  })
+})
+
+describe('fetchUpstreamTarball', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  /**
+   * Stub global fetch to return a multi-chunk stream (so both the pre-sized
+   * and fallback paths do >1 read()), optionally with response headers.
+   */
+  function mockUpstream(chunks: Uint8Array[], headers?: HeadersInit): void {
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        for (const chunk of chunks) controller.enqueue(chunk)
+        controller.close()
+      },
+    })
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response(stream, { headers })),
+    )
+  }
+
+  async function expectTooLarge(promise: Promise<unknown>): Promise<void> {
+    await expect(promise).rejects.toMatchObject({
+      status: 413,
+    } satisfies Partial<HttpError>)
+  }
+
+  it('streams into a pre-sized buffer when Content-Length is present', async () => {
+    mockUpstream(
+      [new Uint8Array([1, 2, 3]), new Uint8Array([4, 5])],
+      { 'content-length': '5' },
+    )
+    const out = await fetchUpstreamTarball('https://example.com/t.tgz', 1024)
+    expect(Array.from(out)).toEqual([1, 2, 3, 4, 5])
+  })
+
+  it('falls back to chunk collection when Content-Length is absent', async () => {
+    mockUpstream([new Uint8Array([9, 8, 7]), new Uint8Array([6])])
+    const out = await fetchUpstreamTarball('https://example.com/t.tgz', 1024)
+    expect(Array.from(out)).toEqual([9, 8, 7, 6])
+  })
+
+  it('rejects a declared Content-Length over the max', async () => {
+    mockUpstream([new Uint8Array([1])], { 'content-length': '2000' })
+    await expectTooLarge(fetchUpstreamTarball('https://example.com/t.tgz', 1024))
+  })
+
+  it('rejects when the body exceeds a Content-Length that understated it', async () => {
+    mockUpstream([new Uint8Array([1, 2, 3, 4])], { 'content-length': '2' })
+    await expectTooLarge(fetchUpstreamTarball('https://example.com/t.tgz', 1024))
+  })
+
+  it('rejects a body exceeding the max with no Content-Length', async () => {
+    mockUpstream([new Uint8Array(2000)])
+    await expectTooLarge(fetchUpstreamTarball('https://example.com/t.tgz', 1024))
   })
 })

--- a/test/unit.test.ts
+++ b/test/unit.test.ts
@@ -411,13 +411,34 @@ describe('fetchUpstreamTarball', () => {
     await expectTooLarge(fetchUpstreamTarball('https://example.com/t.tgz', 1024))
   })
 
-  it('rejects when the body exceeds a Content-Length that understated it', async () => {
+  it('still succeeds when the body exceeds a Content-Length that understated it, within max', async () => {
+    // Content-Length is a sizing hint, not a hard cap: an upstream/proxy that
+    // under-reports it must not fail a download that is otherwise well within
+    // the configured max.
     mockUpstream([new Uint8Array([1, 2, 3, 4])], { 'content-length': '2' })
-    await expectTooLarge(fetchUpstreamTarball('https://example.com/t.tgz', 1024))
+    const out = await fetchUpstreamTarball('https://example.com/t.tgz', 1024)
+    expect(Array.from(out)).toEqual([1, 2, 3, 4])
   })
 
   it('rejects a body exceeding the max with no Content-Length', async () => {
     mockUpstream([new Uint8Array(2000)])
     await expectTooLarge(fetchUpstreamTarball('https://example.com/t.tgz', 1024))
+  })
+
+  it('rejects a body exceeding the max even with an understated Content-Length', async () => {
+    mockUpstream([new Uint8Array(2000)], { 'content-length': '1' })
+    await expectTooLarge(fetchUpstreamTarball('https://example.com/t.tgz', 1024))
+  })
+
+  it('treats a blank Content-Length header as absent, not zero', async () => {
+    mockUpstream([new Uint8Array([1, 2, 3])], { 'content-length': '' })
+    const out = await fetchUpstreamTarball('https://example.com/t.tgz', 1024)
+    expect(Array.from(out)).toEqual([1, 2, 3])
+  })
+
+  it('treats a non-integer Content-Length header as unknown', async () => {
+    mockUpstream([new Uint8Array([1, 2, 3])], { 'content-length': '3.5' })
+    const out = await fetchUpstreamTarball('https://example.com/t.tgz', 1024)
+    expect(Array.from(out)).toEqual([1, 2, 3])
   })
 })


### PR DESCRIPTION
## Summary
- `isWorkspacePackage` re-split/trimmed `WORKSPACE_PACKAGES` on every call even though it's a static Worker var for the isolate's lifetime; memoize it, sharing the split/trim/filter parse with `parseConfiguredPreviewRefs` via a new `splitCsv` util.
- `fetchUpstreamTarball` collected chunks into an array then copied them into a second, final buffer. Upstream responses always declare `Content-Length`, so it now streams straight into one pre-sized buffer in that case, halving peak memory for the common path (falls back to the old approach when it's absent).

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm test` (82/82 passing, 5 new tests covering the pre-sized/fallback paths and all size-guard cases)