### PR TITLE
Fix tarballs missing the tar end-of-archive marker (ERR_PNPM_TARBALL_EXTRACT)

### DIFF
--- a/.github/actions/publish-preview/dist/index.mjs
+++ b/.github/actions/publish-preview/dist/index.mjs
@@ -281,19 +281,6 @@ function createTar(files, opts = {}) {
   }
   return new Uint8Array(buffer);
 }
-function createTarGzipStream(files, opts = {}) {
-  const buffer = createTar(files, opts);
-  return new ReadableStream({
-    start(controller) {
-      controller.enqueue(buffer);
-      controller.close();
-    }
-  }).pipeThrough(new CompressionStream(opts.compression ?? "gzip"));
-}
-async function createTarGzip(files, opts = {}) {
-  const data = await new Response(createTarGzipStream(files, opts)).arrayBuffer().then((buffer) => new Uint8Array(buffer));
-  return data;
-}
 function _writeString(buffer, str, offset, size) {
   const strView = new Uint8Array(buffer, offset, size);
   const te = new TextEncoder();
@@ -449,6 +436,20 @@ function isUnderPackageRoot(name) {
 }
 
 // src/tarball/buildPreviewTarball.ts
+var TAR_MARKER_BYTES = 1024;
+function withEndOfArchiveMarker(tar) {
+  const hasMarker = tar.length >= TAR_MARKER_BYTES && tar.subarray(tar.length - TAR_MARKER_BYTES).every((b) => b === 0);
+  if (hasMarker) return tar;
+  const out = new Uint8Array(tar.length + TAR_MARKER_BYTES);
+  out.set(tar, 0);
+  return out;
+}
+async function gzip(data) {
+  const stream = new Response(data).body.pipeThrough(
+    new CompressionStream("gzip")
+  );
+  return new Uint8Array(await new Response(stream).arrayBuffer());
+}
 var PACKAGE_JSON_NAMES = /* @__PURE__ */ new Set([
   "package/package.json",
   "./package/package.json"
@@ -484,7 +485,7 @@ async function buildPreviewTarball(gzippedTarball, packageName, version, env) {
       attrs: file.attrs
     });
   }
-  const tarball = await createTarGzip(out);
+  const tarball = await gzip(withEndOfArchiveMarker(createTar(out)));
   const { shasum, integrity } = await computeDigests(tarball);
   return { tarball, packageJson: rewritten, shasum, integrity };
 }

--- a/src/tarball/buildPreviewTarball.ts
+++ b/src/tarball/buildPreviewTarball.ts
@@ -1,5 +1,5 @@
 import {
-  createTarGzip,
+  createTar,
   parseTarGzip,
   type ParsedTarFileItem,
   type TarFileInput,
@@ -11,6 +11,37 @@ import {
   assertSafeTarballPath,
   isUnderPackageRoot,
 } from '../security/validateTarballPath'
+
+/** Two 512-byte blocks: the size of a tar end-of-archive marker. */
+const TAR_MARKER_BYTES = 1024
+
+/**
+ * Guarantee the archive ends with the tar end-of-archive marker (two 512-byte
+ * all-zero blocks). nanotar pads the archive up to a full 10240-byte record and
+ * relies on that zero slack to form the marker, but emits NO slack when the
+ * packed size is already an exact multiple of 10240 (and only a single zero
+ * block when it is 512 short of one). Lenient readers (BSD/GNU tar) tolerate a
+ * missing/short marker, but pnpm's strict extractor then reads a header past
+ * EOF and fails with ERR_PNPM_TARBALL_EXTRACT. Append a clean marker whenever
+ * the last 1024 bytes are not already all zero; a no-op for normal archives.
+ */
+function withEndOfArchiveMarker(tar: Uint8Array): Uint8Array {
+  const hasMarker =
+    tar.length >= TAR_MARKER_BYTES &&
+    tar.subarray(tar.length - TAR_MARKER_BYTES).every((b) => b === 0)
+  if (hasMarker) return tar
+  const out = new Uint8Array(tar.length + TAR_MARKER_BYTES)
+  out.set(tar, 0)
+  return out
+}
+
+/** Gzip a byte buffer using the runtime's CompressionStream (deterministic). */
+async function gzip(data: Uint8Array): Promise<Uint8Array> {
+  const stream = new Response(data).body!.pipeThrough(
+    new CompressionStream('gzip'),
+  )
+  return new Uint8Array(await new Response(stream).arrayBuffer())
+}
 
 export const PACKAGE_JSON_NAMES = new Set([
   'package/package.json',
@@ -116,7 +147,10 @@ export async function buildPreviewTarball(
     })
   }
 
-  const tarball = await createTarGzip(out)
+  // Build the raw tar, ensure it carries the end-of-archive marker (nanotar
+  // can omit it, see withEndOfArchiveMarker), then gzip. Integrity/shasum are
+  // computed over these final bytes, so they always match what is served.
+  const tarball = await gzip(withEndOfArchiveMarker(createTar(out)))
   const { shasum, integrity } = await computeDigests(tarball)
   return { tarball, packageJson: rewritten, shasum, integrity }
 }

--- a/test/buildPreviewTarball.test.ts
+++ b/test/buildPreviewTarball.test.ts
@@ -76,4 +76,52 @@ describe('buildPreviewTarball', () => {
       buildPreviewTarball(upstream, 'vite-plus', '0.0.0-commit.a832a55', env),
     ).rejects.toThrow(/missing package\/package\.json/)
   })
+
+  // Regression: a tar archive must end with two 512-byte all-zero blocks
+  // (the end-of-archive marker). nanotar rounds the archive up to a full
+  // 10240-byte record and the zero slack forms that marker, EXCEPT when the
+  // packed size is already an exact multiple of 10240, where it emitted no
+  // marker at all. Lenient tools (BSD/GNU tar) tolerate the omission, but
+  // pnpm's strict extractor reads a header past EOF and fails with
+  // ERR_PNPM_TARBALL_EXTRACT ("Invalid checksum ... Expected 0, got NaN").
+  // See @voidzero-dev/vite-plus-core@0.0.0-commit.14f13284 (packed to exactly
+  // 5038080 = 492 * 10240 bytes).
+  it('always emits a valid end-of-archive marker, even on a 10240-byte boundary', async () => {
+    async function gunzip(gz: Uint8Array): Promise<Uint8Array> {
+      const stream = new Response(gz).body!.pipeThrough(
+        new DecompressionStream('gzip'),
+      )
+      return new Uint8Array(await new Response(stream).arrayBuffer())
+    }
+
+    const endsWithMarker = (tar: Uint8Array): boolean => {
+      if (tar.length < 1024 || tar.length % 512 !== 0) return false
+      return tar.subarray(tar.length - 1024).every((b) => b === 0)
+    }
+
+    // Sweep the packed size across a full 10240-byte record by growing one
+    // filler file 512 bytes at a time. 20 consecutive block counts cover every
+    // 512-aligned residue mod 10240, so exactly one lands on the boundary that
+    // triggered the bug; assert the marker is present for all of them.
+    const offenders: number[] = []
+    for (let blocks = 1; blocks <= 20; blocks++) {
+      const upstream = await createTarGzip([
+        {
+          name: 'package/package.json',
+          data: JSON.stringify({ name: 'vite-plus', version: '1891' }),
+        },
+        { name: 'package/filler.bin', data: new Uint8Array(blocks * 512).fill(65) },
+      ])
+      const build = await buildPreviewTarball(
+        upstream,
+        'vite-plus',
+        '0.0.0-commit.a832a55',
+        env,
+      )
+      const tar = await gunzip(build.tarball)
+      if (!endsWithMarker(tar)) offenders.push(tar.length)
+    }
+
+    expect(offenders).toEqual([])
+  })
 })


### PR DESCRIPTION
## Problem
`vp` installs of some preview builds fail in pnpm:

```
ERR_PNPM_TARBALL_EXTRACT  Failed to add tarball from
".../tarballs/@voidzero-dev/vite-plus-core/0.0.0-commit.14f13284....tgz" to store:
Invalid checksum for TAR header at offset 5038080. Expected 0, got NaN
```

## Root cause
`buildPreviewTarball` repacks upstream tarballs with nanotar's `createTarGzip`. nanotar rounds the archive up to a full 10240-byte record and relies on the zero slack to form the mandatory end-of-archive marker (two 512-byte zero blocks). When the packed size is already an **exact multiple of 10240**, it adds no slack and emits **no marker** (and only a single block when the size is 512 short of a record).

Lenient readers (BSD/GNU `tar`, `gzip -t`) tolerate the omission; pnpm's strict extractor reads a header past EOF and fails with `Expected 0, got NaN`. `@voidzero-dev/vite-plus-core@0.0.0-commit.14f13284` repacks to exactly `5038080 = 492 * 10240` bytes, hitting the boundary.

This is unrelated to #49 (which only touched the download path); reverting it could not have helped.

## Fix
Build the raw tar, guarantee the marker (append two zero blocks whenever the last 1024 bytes are not already zero), then gzip. A **no-op for normal archives**, so every already-correct tarball's bytes and integrity are byte-identical; only boundary cases change. Rebuilt the `publish-preview` action bundle, which packs via the same `buildPreviewTarball`.

## Test plan
- [x] Added regression test that sweeps packed sizes across a full 10240-byte record (guaranteeing the boundary case) and asserts a valid end-of-archive marker; it fails on `main`, passes here.
- [x] `pnpm typecheck`, `pnpm test` (78/78)
- [x] Verified end-to-end: a marker-less boundary archive built through the fixed code extracts cleanly under strict `tar`.

## Follow-up (post-merge)
The already-corrupted object in R2 for `vite-plus-core@0.0.0-commit.14f13284` must be purged/rebuilt so live installs recover; deploying the Worker alone won't rewrite existing bytes.