### PR TITLE
Per-package atomic publish: metas travel with bytes, ref registers last

### DIFF
--- a/.github/actions/publish-preview/dist/index.mjs
+++ b/.github/actions/publish-preview/dist/index.mjs
@@ -541,11 +541,13 @@ async function withRetry(label, fn, attempts = 4) {
   }
   throw new Error(`${label} failed after ${attempts} attempts: ${lastErr}`);
 }
+var TRANSFER_TIMEOUT_MS = 12e4;
+var PUBLISH_TIMEOUT_MS = 3e4;
 async function fetchUpstream(env, name, version) {
   const url = toPkgPrNewUrl(env, name, version);
   if (!url) throw new Error(`cannot build pkg.pr.new url for ${name}@${version}`);
   return withRetry(`download ${name}`, async () => {
-    const res = await fetch(url);
+    const res = await fetch(url, { signal: AbortSignal.timeout(TRANSFER_TIMEOUT_MS) });
     if (!res.ok) throw new Error(`HTTP ${res.status} for ${url}`);
     return new Uint8Array(await res.arrayBuffer());
   });
@@ -555,7 +557,8 @@ async function uploadTarball(bridge, token, name, version, bytes) {
     const res = await fetch(`${bridge}/-/tarball/${name}/${version}.tgz`, {
       method: "PUT",
       headers: { authorization: `Bearer ${token}`, "content-type": "application/gzip" },
-      body: bytes
+      body: bytes,
+      signal: AbortSignal.timeout(TRANSFER_TIMEOUT_MS)
     });
     if (!res.ok) throw new Error(`HTTP ${res.status}: ${await res.text().catch(() => "")}`);
   });
@@ -581,7 +584,8 @@ async function main() {
     const res = await fetch(`${bridge}/-/publish`, {
       method: "POST",
       headers: { authorization: `Bearer ${token}`, "content-type": "application/json" },
-      body: JSON.stringify(body)
+      body: JSON.stringify(body),
+      signal: AbortSignal.timeout(PUBLISH_TIMEOUT_MS)
     });
     if (!res.ok) throw new Error(`HTTP ${res.status}: ${await res.text().catch(() => "")}`);
   });

--- a/.github/actions/publish-preview/dist/index.mjs
+++ b/.github/actions/publish-preview/dist/index.mjs
@@ -576,24 +576,34 @@ async function main() {
     WORKSPACE_PACKAGES: input("workspace-packages") || "vite-plus,@voidzero-dev/vite-plus-*"
   };
   console.log(`publishing ${version} to ${bridge}`);
-  const packages = [];
-  const buildAndUpload = async (name, ver) => {
+  let published = 0;
+  const postPublish = (body, label) => withRetry(label, async () => {
+    const res = await fetch(`${bridge}/-/publish`, {
+      method: "POST",
+      headers: { authorization: `Bearer ${token}`, "content-type": "application/json" },
+      body: JSON.stringify(body)
+    });
+    if (!res.ok) throw new Error(`HTTP ${res.status}: ${await res.text().catch(() => "")}`);
+  });
+  const publishPackage = async (name, ver) => {
     const upstream = await fetchUpstream(env, name, ver);
     const build = await buildPreviewTarball(upstream, name, ver, env);
     await uploadTarball(bridge, token, name, ver, build.tarball);
-    console.log(`  \u2713 ${name}@${ver} (${build.tarball.byteLength} bytes)`);
-    return {
+    const pkg = {
       name,
       version: ver,
       packageJson: build.packageJson,
       integrity: build.integrity,
       shasum: build.shasum
     };
+    await postPublish({ ref, prUrl, register: false, packages: [pkg] }, `publish ${name}`);
+    published++;
+    console.log(`  \u2713 ${name}@${ver} (${build.tarball.byteLength} bytes)`);
+    return pkg;
   };
   let vitePlusPackageJson;
   for (const name of PREVIEW_PACKAGES) {
-    const pkg = await buildAndUpload(name, version);
-    packages.push(pkg);
+    const pkg = await publishPackage(name, version);
     if (name === "vite-plus") vitePlusPackageJson = pkg.packageJson;
   }
   const optionalDeps = vitePlusPackageJson?.optionalDependencies ?? {};
@@ -601,17 +611,10 @@ async function main() {
     ([name]) => isWorkspacePackage(name, env) && !isPreviewPackage(name)
   );
   for (const [name, depVersion] of binaries) {
-    packages.push(await buildAndUpload(name, depVersion));
+    await publishPackage(name, depVersion);
   }
-  await withRetry("publish", async () => {
-    const res = await fetch(`${bridge}/-/publish`, {
-      method: "POST",
-      headers: { authorization: `Bearer ${token}`, "content-type": "application/json" },
-      body: JSON.stringify({ ref, prUrl, packages })
-    });
-    if (!res.ok) throw new Error(`HTTP ${res.status}: ${await res.text().catch(() => "")}`);
-  });
-  console.log(`published ${packages.length} packages, registered ${ref}`);
+  await postPublish({ ref, prUrl, packages: [] }, "register ref");
+  console.log(`published ${published} packages, registered ${ref}`);
   const out = process.env.GITHUB_OUTPUT;
   if (out) {
     const { appendFileSync } = await import("node:fs");

--- a/.github/actions/publish-preview/src/index.ts
+++ b/.github/actions/publish-preview/src/index.ts
@@ -52,6 +52,15 @@ async function withRetry<T>(label: string, fn: () => Promise<T>, attempts = 4): 
   throw new Error(`${label} failed after ${attempts} attempts: ${lastErr}`)
 }
 
+// Per-attempt fetch deadlines. Without one, a hung connection stalls up to
+// undici's ~5-minute defaults, and 4 retry attempts across ~11 packages can
+// zombie a publish for tens of minutes (the 2026-07-02 incident's cancelled
+// attempt ran 21 minutes mid-publish). Bounding each attempt keeps retries
+// snappy and the whole run inside a predictable window. Transfers move up to
+// ~19 MB per request; the register call is a small JSON POST.
+const TRANSFER_TIMEOUT_MS = 120_000
+const PUBLISH_TIMEOUT_MS = 30_000
+
 async function fetchUpstream(
   env: RewriteEnv,
   name: string,
@@ -60,7 +69,7 @@ async function fetchUpstream(
   const url = toPkgPrNewUrl(env, name, version)
   if (!url) throw new Error(`cannot build pkg.pr.new url for ${name}@${version}`)
   return withRetry(`download ${name}`, async () => {
-    const res = await fetch(url)
+    const res = await fetch(url, { signal: AbortSignal.timeout(TRANSFER_TIMEOUT_MS) })
     if (!res.ok) throw new Error(`HTTP ${res.status} for ${url}`)
     return new Uint8Array(await res.arrayBuffer())
   })
@@ -78,6 +87,7 @@ async function uploadTarball(
       method: 'PUT',
       headers: { authorization: `Bearer ${token}`, 'content-type': 'application/gzip' },
       body: bytes,
+      signal: AbortSignal.timeout(TRANSFER_TIMEOUT_MS),
     })
     if (!res.ok) throw new Error(`HTTP ${res.status}: ${await res.text().catch(() => '')}`)
   })
@@ -111,6 +121,7 @@ async function main(): Promise<void> {
         method: 'POST',
         headers: { authorization: `Bearer ${token}`, 'content-type': 'application/json' },
         body: JSON.stringify(body),
+        signal: AbortSignal.timeout(PUBLISH_TIMEOUT_MS),
       })
       if (!res.ok) throw new Error(`HTTP ${res.status}: ${await res.text().catch(() => '')}`)
     })

--- a/.github/actions/publish-preview/src/index.ts
+++ b/.github/actions/publish-preview/src/index.ts
@@ -103,31 +103,48 @@ async function main(): Promise<void> {
   }
 
   console.log(`publishing ${version} to ${bridge}`)
-  const packages: PublishPackage[] = []
+  let published = 0
+
+  const postPublish = (body: Record<string, unknown>, label: string) =>
+    withRetry(label, async () => {
+      const res = await fetch(`${bridge}/-/publish`, {
+        method: 'POST',
+        headers: { authorization: `Bearer ${token}`, 'content-type': 'application/json' },
+        body: JSON.stringify(body),
+      })
+      if (!res.ok) throw new Error(`HTTP ${res.status}: ${await res.text().catch(() => '')}`)
+    })
 
   // Download from pkg.pr.new, rewrite + re-pack + hash, upload the bytes, and
-  // return the meta to publish. Reuses the Worker's own build so CI's artifact
-  // is exactly what the Worker would describe.
-  const buildAndUpload = async (name: string, ver: string): Promise<PublishPackage> => {
+  // immediately publish this package's meta (register: false), so the stored
+  // tarball and the meta the packument serves can never diverge for longer
+  // than this one package's upload. A run cancelled part-way leaves later
+  // packages untouched instead of stranding bytes without metas (the mixed
+  // state a cancelled run previously served for its whole upload window).
+  // Reuses the Worker's own build so CI's artifact is exactly what the Worker
+  // would describe.
+  const publishPackage = async (name: string, ver: string): Promise<PublishPackage> => {
     const upstream = await fetchUpstream(env, name, ver)
     const build = await buildPreviewTarball(upstream, name, ver, env)
     await uploadTarball(bridge, token, name, ver, build.tarball)
-    console.log(`  ✓ ${name}@${ver} (${build.tarball.byteLength} bytes)`)
-    return {
+    const pkg: PublishPackage = {
       name,
       version: ver,
       packageJson: build.packageJson,
       integrity: build.integrity,
       shasum: build.shasum,
     }
+    await postPublish({ ref, prUrl, register: false, packages: [pkg] }, `publish ${name}`)
+    published++
+    console.log(`  ✓ ${name}@${ver} (${build.tarball.byteLength} bytes)`)
+    return pkg
   }
 
   // Preview packages first; vite-plus's rewritten optionalDependencies name the
   // platform binaries (each at the version vite-plus declares for it).
   let vitePlusPackageJson: Record<string, any> | undefined
   for (const name of PREVIEW_PACKAGES) {
-    const pkg = await buildAndUpload(name, version)
-    packages.push(pkg)
+    const pkg = await publishPackage(name, version)
     if (name === 'vite-plus') vitePlusPackageJson = pkg.packageJson
   }
 
@@ -136,20 +153,14 @@ async function main(): Promise<void> {
     ([name]) => isWorkspacePackage(name, env) && !isPreviewPackage(name),
   )
   for (const [name, depVersion] of binaries) {
-    packages.push(await buildAndUpload(name, depVersion))
+    await publishPackage(name, depVersion)
   }
 
-  // Publish the metas + register the ref in one call (after every upload, so a
-  // stored meta-with-integrity always has its bytes in R2).
-  await withRetry('publish', async () => {
-    const res = await fetch(`${bridge}/-/publish`, {
-      method: 'POST',
-      headers: { authorization: `Bearer ${token}`, 'content-type': 'application/json' },
-      body: JSON.stringify({ ref, prUrl, packages }),
-    })
-    if (!res.ok) throw new Error(`HTTP ${res.status}: ${await res.text().catch(() => '')}`)
-  })
-  console.log(`published ${packages.length} packages, registered ${ref}`)
+  // Every package's bytes + meta are stored; registering the ref last flips
+  // the whole version visible atomically (a brand-new ref is not served at
+  // all until this succeeds).
+  await postPublish({ ref, prUrl, packages: [] }, 'register ref')
+  console.log(`published ${published} packages, registered ${ref}`)
 
   const out = process.env.GITHUB_OUTPUT
   if (out) {

--- a/src/app.ts
+++ b/src/app.ts
@@ -14,6 +14,7 @@ import {
   latestVersionByPr,
   registerRef,
 } from './preview/getConfiguredRefs'
+import { parseConfiguredPreviewRefs } from './preview/parseConfiguredPreviewRefs'
 import {
   readMetaIndex,
   removeFromMetaIndex,
@@ -203,17 +204,27 @@ app.put('/-/tarball/*', async (c) => {
 })
 
 /**
- * Publish preview metadata and register the ref (admin), in one call. Body:
+ * Publish preview metadata and (by default) register the ref (admin). Body:
  * `{ "ref": "commit.<sha>", "packages": [{ name, version, packageJson,
- * integrity, shasum }] }`. The publish action calls this AFTER uploading the
- * tarballs, so a stored meta-with-integrity always has its bytes in R2. Each
- * package's meta is what the packument serves (package.json fields + integrity).
+ * integrity, shasum }], "register"?: boolean }`. The publish action calls this
+ * AFTER uploading each tarball, so a stored meta-with-integrity always has its
+ * bytes in R2. Each package's meta is what the packument serves (package.json
+ * fields + integrity).
+ *
+ * Two-phase protocol (what the publish action uses): one `register: false`
+ * call per package right after its tarball upload, so bytes and meta never
+ * diverge for longer than that single upload, then one final call with
+ * `packages: []` that registers the ref, flipping the whole version visible
+ * atomically. A run cancelled mid-way leaves only invisible (unregistered)
+ * artifacts instead of a mixed served state. A single register-everything
+ * call (the old protocol) still works unchanged.
  */
 app.post('/-/publish', async (c) => {
   admin(c)
   const body = (await c.req.json().catch(() => ({}))) as {
     ref?: string
     prUrl?: string
+    register?: boolean
     packages?: Array<{
       name?: string
       version?: string
@@ -225,9 +236,14 @@ app.post('/-/publish', async (c) => {
   const ref = (body.ref ?? '').trim()
   // Optional: the action runs on push commits too, where there is no PR.
   const prUrl = (body.prUrl ?? '').trim() || undefined
+  const register = body.register !== false
   const packages = Array.isArray(body.packages) ? body.packages : []
   if (!ref) throw new HttpError(400, 'Missing ref')
-  if (packages.length === 0) throw new HttpError(400, 'Missing packages')
+  // A meta-only call with nothing to store is a no-op; only the final
+  // register-only call may carry an empty packages list.
+  if (packages.length === 0 && !register) {
+    throw new HttpError(400, 'Missing packages')
+  }
 
   // Validate everything up front (so a bad package can't leave half-written
   // metas), then write the independent meta keys in parallel.
@@ -267,12 +283,16 @@ app.post('/-/publish', async (c) => {
   let parsed
   try {
     // registerRef parses + validates the ref and returns it. Record this run's
-    // server-stamped publish time and (when present) the source PR url.
-    parsed = await registerRef(c.env, ref, { publishedAt, prUrl })
+    // server-stamped publish time and (when present) the source PR url. A
+    // register:false call only validates the ref; the version stays invisible
+    // until the final register call.
+    parsed = register
+      ? await registerRef(c.env, ref, { publishedAt, prUrl })
+      : parseConfiguredPreviewRefs(ref)[0]
   } catch (err) {
     throw new HttpError(400, `Invalid or unregisterable ref: ${ref} (${err})`)
   }
-  return c.json({ ref, version: parsed.version, published }, 201)
+  return c.json({ ref, version: parsed.version, published, registered: register }, 201)
 })
 
 /** List the registered preview refs (the runtime R2 index). Public read. */

--- a/src/tarball/getPreviewBuild.ts
+++ b/src/tarball/getPreviewBuild.ts
@@ -5,6 +5,7 @@ import { isPreviewPackage } from '../preview/packages'
 import { platformInfoFromName } from '../preview/platformInfo'
 import { toPkgPrNewUrl } from '../preview/toPkgPrNewUrl'
 import { metaKey, tarballKey } from '../cache/r2Cache'
+import { upsertMetaIndex } from '../preview/metaIndex'
 import { tarballCacheControl } from '../cache/headers'
 import {
   buildPreviewTarball,
@@ -43,6 +44,11 @@ async function buildAndStore(
     integrity: build.integrity,
     publishedAt,
   }
+  // Write the tarball and BOTH meta sources together. The rebuild replaces any
+  // previously published bytes (a workerd gzip stream differs byte-for-byte
+  // from CI's Node gzip of the same tar), so a stale meta-index entry would
+  // otherwise advertise an integrity the served tarball can no longer match,
+  // and the packument would flap between the two sources.
   await Promise.all([
     env.STORAGE.put(tarballKey(name, version), build.tarball, {
       httpMetadata: { contentType: 'application/gzip', cacheControl },
@@ -50,6 +56,7 @@ async function buildAndStore(
     env.STORAGE.put(metaKey(name, version), JSON.stringify(meta), {
       httpMetadata: { contentType: 'application/json', cacheControl },
     }),
+    upsertMetaIndex(env, name, version, meta),
   ])
 
   return { ...build, publishedAt }

--- a/test/worker.test.ts
+++ b/test/worker.test.ts
@@ -1089,6 +1089,98 @@ describe('admin: publish', () => {
   })
 })
 
+describe('admin: per-package atomic publish', () => {
+  // The publish action uploads each tarball and publishes its meta immediately
+  // (register: false), then registers the ref once at the end (packages: []).
+  // A cancelled run can then never leave tarball bytes visible without their
+  // matching meta: metas travel with bytes, and visibility flips atomically at
+  // the final register call.
+  const sha = 'abc1234'
+  const ver = `0.0.0-commit.${sha}`
+  const pkg = {
+    name: 'vite-plus',
+    version: ver,
+    packageJson: { name: 'vite-plus', version: ver },
+    integrity: 'sha512-atomic',
+    shasum: 'a1'.repeat(20),
+  }
+
+  const publish = (body: Record<string, any>) =>
+    SELF.fetch(`${BASE}/-/publish`, {
+      method: 'POST',
+      headers: { ...AUTH, 'content-type': 'application/json' },
+      body: JSON.stringify(body),
+    })
+
+  it('register:false stores the meta without registering the ref; a final packages-empty call registers it', async () => {
+    // Phase 1: meta-only publish.
+    const res1 = await publish({ ref: `commit.${sha}`, register: false, packages: [pkg] })
+    expect(res1.status).toBe(201)
+    expect(await res1.json()).toMatchObject({ registered: false })
+
+    // Meta and index are written...
+    const meta = (await (await env.STORAGE.get(metaKey('vite-plus', ver)))!.json()) as Record<string, any>
+    expect(meta.integrity).toBe('sha512-atomic')
+
+    // ...but the ref is NOT registered: not listed, not injected.
+    const refs = (await (await SELF.fetch(`${BASE}/-/refs`)).json()) as Record<string, any>
+    expect(refs.refs.some((r: any) => r.ref === `commit.${sha}`)).toBe(false)
+    const pack1 = (await (
+      await SELF.fetch(`${BASE}/vite-plus`, { headers: { accept: 'application/json' } })
+    ).json()) as Record<string, any>
+    expect(pack1.versions[ver]).toBeUndefined()
+
+    // Phase 2: register-only call (empty packages) flips visibility.
+    const res2 = await publish({ ref: `commit.${sha}`, packages: [] })
+    expect(res2.status).toBe(201)
+    expect(await res2.json()).toMatchObject({ registered: true })
+
+    const refs2 = (await (await SELF.fetch(`${BASE}/-/refs`)).json()) as Record<string, any>
+    expect(refs2.refs.some((r: any) => r.ref === `commit.${sha}`)).toBe(true)
+    const pack2 = (await (
+      await SELF.fetch(`${BASE}/vite-plus`, { headers: { accept: 'application/json' } })
+    ).json()) as Record<string, any>
+    expect(pack2.versions[ver]?.dist?.integrity).toBe('sha512-atomic')
+  })
+
+  it('rejects a register:false call with no packages (would be a no-op)', async () => {
+    const res = await publish({ ref: `commit.${sha}`, register: false, packages: [] })
+    expect(res.status).toBe(400)
+  })
+})
+
+describe('on-demand build consistency', () => {
+  it('an in-worker rebuild updates the meta-index along with the per-version meta', async () => {
+    // Simulate the gap state that caused meta flapping in production: the
+    // version is registered but its meta artifacts are gone. The packument
+    // request triggers the on-demand build, which must repopulate BOTH meta
+    // sources; a divergent index (stale or missing entry) makes the packument
+    // flip between integrities depending on which source a rebuild reads.
+    await env.STORAGE.delete(metaKey('vite-plus', FIXTURE_VERSION))
+    const idx = (await (await env.STORAGE.get(metaIndexKey('vite-plus')))?.json()) as
+      | Record<string, any>
+      | undefined
+    if (idx) {
+      delete idx[FIXTURE_VERSION]
+      await env.STORAGE.put(metaIndexKey('vite-plus'), JSON.stringify(idx))
+    }
+
+    // Triggers getPreviewMeta -> buildAndStore for the fixture version.
+    const pack = (await (
+      await SELF.fetch(`${BASE}/vite-plus`, { headers: { accept: 'application/json' } })
+    ).json()) as Record<string, any>
+    const built = pack.versions[FIXTURE_VERSION]?.dist?.integrity
+    expect(built).toBeTruthy()
+
+    // The rebuild must keep the two meta sources consistent.
+    const meta = (await (await env.STORAGE.get(metaKey('vite-plus', FIXTURE_VERSION)))!.json()) as Record<string, any>
+    const index = (await (await env.STORAGE.get(metaIndexKey('vite-plus')))!.json()) as Record<string, any>
+    expect(index[FIXTURE_VERSION]).toBeTruthy()
+    expect(index[FIXTURE_VERSION].integrity).toBe(meta.integrity)
+    expect(built).toBe(meta.integrity)
+  })
+})
+
 describe('health', () => {
   it('responds ok', async () => {
     const res = await SELF.fetch(`${BASE}/_health`)


### PR DESCRIPTION
## Incident (2026-07-02, sha 0fecc75a)
A publish run was cancelled mid-way (re-running a workflow auto-cancels the in-flight attempt). It had already overwritten the R2 tarballs for vite-plus/core with new bytes, but never reached the single end-of-run `/-/publish`, so for ~20 minutes the packument advertised metas that no longer matched the served bytes. Every install in the window failed with `ERR_PNPM_TARBALL_INTEGRITY`, and the mixed state got captured by CDN edge caches (`immutable`, deployment-scoped) and pnpm client metadata caches, both of which outlived the server-side self-heal.

## Fix
- `/-/publish` accepts `register: false` (store metas only, ref stays unregistered/invisible) and a final `packages: []` register-only call. The old single-call protocol is unchanged.
- The publish action now uploads each tarball and immediately publishes that package's meta, then registers the ref once at the end. Bytes and meta can no longer diverge beyond a single package's upload, and a cancelled run strands only invisible artifacts instead of serving mixed state.
- The worker's on-demand rebuild (`buildAndStore`) now updates the meta-index alongside the per-version meta. Previously it skipped the index, leaving two disagreeing meta sources: the packument flapped between them (workerd's gzip output never matches CI's Node gzip, so a stale index integrity was unsatisfiable by the rebuilt bytes).

## Test plan
- [x] New failing-first tests: two-phase publish protocol (meta-only invisible, register-only flips visible) and on-demand-rebuild index consistency
- [x] `pnpm test` 81/81, `pnpm typecheck`
- [x] Action bundle rebuilt (`pnpm build:action`)

## Follow-ups (separate)
- Content-keyed tarball paths in `dist.tarball` so a poisoned edge/client cache can never outlive a fix (CDN ignores query strings, so it must be path-based)
- vite-plus workflow: reconsider `continue-on-error: true` on the register step and cancellation of in-flight publishes