### PR TITLE
Split registration out of /-/publish into a dedicated /-/register

### DIFF
--- a/.github/actions/publish-preview/dist/index.mjs
+++ b/.github/actions/publish-preview/dist/index.mjs
@@ -580,8 +580,8 @@ async function main() {
   };
   console.log(`publishing ${version} to ${bridge}`);
   let published = 0;
-  const postPublish = (body, label) => withRetry(label, async () => {
-    const res = await fetch(`${bridge}/-/publish`, {
+  const post = (path, body, label) => withRetry(label, async () => {
+    const res = await fetch(`${bridge}${path}`, {
       method: "POST",
       headers: { authorization: `Bearer ${token}`, "content-type": "application/json" },
       body: JSON.stringify(body),
@@ -600,7 +600,7 @@ async function main() {
       integrity: build.integrity,
       shasum: build.shasum
     };
-    await postPublish({ ref, prUrl, register: false, packages: [pkg] }, `publish ${name}`);
+    await post("/-/publish", { ref, packages: [pkg] }, `publish ${name}`);
     published++;
     console.log(`  \u2713 ${name}@${ver} (${build.tarball.byteLength} bytes)`);
     return pkg;
@@ -617,7 +617,7 @@ async function main() {
   for (const [name, depVersion] of binaries) {
     await publishPackage(name, depVersion);
   }
-  await postPublish({ ref, prUrl, packages: [] }, "register ref");
+  await post("/-/register", { ref, prUrl }, "register ref");
   console.log(`published ${published} packages, registered ${ref}`);
   const out = process.env.GITHUB_OUTPUT;
   if (out) {

--- a/.github/actions/publish-preview/src/index.ts
+++ b/.github/actions/publish-preview/src/index.ts
@@ -115,9 +115,9 @@ async function main(): Promise<void> {
   console.log(`publishing ${version} to ${bridge}`)
   let published = 0
 
-  const postPublish = (body: Record<string, unknown>, label: string) =>
+  const post = (path: string, body: Record<string, unknown>, label: string) =>
     withRetry(label, async () => {
-      const res = await fetch(`${bridge}/-/publish`, {
+      const res = await fetch(`${bridge}${path}`, {
         method: 'POST',
         headers: { authorization: `Bearer ${token}`, 'content-type': 'application/json' },
         body: JSON.stringify(body),
@@ -127,13 +127,12 @@ async function main(): Promise<void> {
     })
 
   // Download from pkg.pr.new, rewrite + re-pack + hash, upload the bytes, and
-  // immediately publish this package's meta (register: false), so the stored
-  // tarball and the meta the packument serves can never diverge for longer
-  // than this one package's upload. A run cancelled part-way leaves later
-  // packages untouched instead of stranding bytes without metas (the mixed
-  // state a cancelled run previously served for its whole upload window).
-  // Reuses the Worker's own build so CI's artifact is exactly what the Worker
-  // would describe.
+  // immediately publish this package's meta, so the stored tarball and the
+  // meta the packument serves can never diverge for longer than this one
+  // package's upload. A run cancelled part-way leaves later packages untouched
+  // instead of stranding bytes without metas (the mixed state a cancelled run
+  // previously served for its whole upload window). Reuses the Worker's own
+  // build so CI's artifact is exactly what the Worker would describe.
   const publishPackage = async (name: string, ver: string): Promise<PublishPackage> => {
     const upstream = await fetchUpstream(env, name, ver)
     const build = await buildPreviewTarball(upstream, name, ver, env)
@@ -145,7 +144,7 @@ async function main(): Promise<void> {
       integrity: build.integrity,
       shasum: build.shasum,
     }
-    await postPublish({ ref, prUrl, register: false, packages: [pkg] }, `publish ${name}`)
+    await post('/-/publish', { ref, packages: [pkg] }, `publish ${name}`)
     published++
     console.log(`  ✓ ${name}@${ver} (${build.tarball.byteLength} bytes)`)
     return pkg
@@ -170,7 +169,7 @@ async function main(): Promise<void> {
   // Every package's bytes + meta are stored; registering the ref last flips
   // the whole version visible atomically (a brand-new ref is not served at
   // all until this succeeds).
-  await postPublish({ ref, prUrl, packages: [] }, 'register ref')
+  await post('/-/register', { ref, prUrl }, 'register ref')
   console.log(`published ${published} packages, registered ${ref}`)
 
   const out = process.env.GITHUB_OUTPUT

--- a/docs/ci-setup.md
+++ b/docs/ci-setup.md
@@ -13,9 +13,12 @@ The bridge ships a reusable action that does the CPU-heavy work in CI: for each
 package (the two preview packages and every platform binary in vite-plus's
 `optionalDependencies`) it downloads the pkg.pr.new build, rewrites
 `package/package.json` (name/version, plus deps for the preview packages),
-re-packs, hashes, `PUT`s the tarball, then `POST`s the metadata and registers the
-ref. The Worker then only serves bytes from R2, with `dist.integrity` matching the
-exact bytes served.
+re-packs, hashes, `PUT`s the tarball, and immediately `POST`s that package's
+metadata (`/-/publish`), so stored bytes and served metadata can never diverge
+for longer than one package's upload. A final `POST /-/register` registers the
+ref, flipping the whole version visible atomically; a run cancelled mid-way
+leaves only invisible artifacts. The Worker then only serves bytes from R2,
+with `dist.integrity` matching the exact bytes served.
 
 ## Setup
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -204,27 +204,21 @@ app.put('/-/tarball/*', async (c) => {
 })
 
 /**
- * Publish preview metadata and (by default) register the ref (admin). Body:
- * `{ "ref": "commit.<sha>", "packages": [{ name, version, packageJson,
- * integrity, shasum }], "register"?: boolean }`. The publish action calls this
- * AFTER uploading each tarball, so a stored meta-with-integrity always has its
- * bytes in R2. Each package's meta is what the packument serves (package.json
- * fields + integrity).
+ * Publish preview metadata (admin). Body: `{ "ref": "commit.<sha>",
+ * "packages": [{ name, version, packageJson, integrity, shasum }] }`. The
+ * publish action calls this right AFTER uploading each package's tarball, so a
+ * stored meta-with-integrity always has its bytes in R2 and the two can never
+ * diverge for longer than one package's upload. Each package's meta is what
+ * the packument serves (package.json fields + integrity).
  *
- * Two-phase protocol (what the publish action uses): one `register: false`
- * call per package right after its tarball upload, so bytes and meta never
- * diverge for longer than that single upload, then one final call with
- * `packages: []` that registers the ref, flipping the whole version visible
- * atomically. A run cancelled mid-way leaves only invisible (unregistered)
- * artifacts instead of a mixed served state. A single register-everything
- * call (the old protocol) still works unchanged.
+ * Publishing does NOT register the ref: the version stays invisible until the
+ * final `/-/register` call flips it on atomically, so a run cancelled mid-way
+ * leaves only invisible artifacts instead of a mixed served state.
  */
 app.post('/-/publish', async (c) => {
   admin(c)
   const body = (await c.req.json().catch(() => ({}))) as {
     ref?: string
-    prUrl?: string
-    register?: boolean
     packages?: Array<{
       name?: string
       version?: string
@@ -234,16 +228,9 @@ app.post('/-/publish', async (c) => {
     }>
   }
   const ref = (body.ref ?? '').trim()
-  // Optional: the action runs on push commits too, where there is no PR.
-  const prUrl = (body.prUrl ?? '').trim() || undefined
-  const register = body.register !== false
   const packages = Array.isArray(body.packages) ? body.packages : []
   if (!ref) throw new HttpError(400, 'Missing ref')
-  // A meta-only call with nothing to store is a no-op; only the final
-  // register-only call may carry an empty packages list.
-  if (packages.length === 0 && !register) {
-    throw new HttpError(400, 'Missing packages')
-  }
+  if (packages.length === 0) throw new HttpError(400, 'Missing packages')
 
   // Validate everything up front (so a bad package can't leave half-written
   // metas), then write the independent meta keys in parallel.
@@ -282,17 +269,41 @@ app.post('/-/publish', async (c) => {
 
   let parsed
   try {
-    // registerRef parses + validates the ref and returns it. Record this run's
-    // server-stamped publish time and (when present) the source PR url. A
-    // register:false call only validates the ref; the version stays invisible
-    // until the final register call.
-    parsed = register
-      ? await registerRef(c.env, ref, { publishedAt, prUrl })
-      : parseConfiguredPreviewRefs(ref)[0]
+    // Validate the ref shape (the version being published must belong to a
+    // well-formed commit ref); registration itself happens on /-/register.
+    parsed = parseConfiguredPreviewRefs(ref)[0]
+  } catch (err) {
+    throw new HttpError(400, `Invalid ref: ${ref} (${err})`)
+  }
+  return c.json({ ref, version: parsed.version, published }, 201)
+})
+
+/**
+ * Register a ref (admin), making its published versions visible in packuments.
+ * Body: `{ "ref": "commit.<sha>", "prUrl"?: string }`. The publish action
+ * calls this ONCE, after every package's tarball + meta are stored, so a new
+ * version appears atomically with all its artifacts in place. The publish
+ * time is stamped server-side here (the moment the release became visible).
+ */
+app.post('/-/register', async (c) => {
+  admin(c)
+  const body = (await c.req.json().catch(() => ({}))) as {
+    ref?: string
+    prUrl?: string
+  }
+  const ref = (body.ref ?? '').trim()
+  // Optional: the action runs on push commits too, where there is no PR.
+  const prUrl = (body.prUrl ?? '').trim() || undefined
+  if (!ref) throw new HttpError(400, 'Missing ref')
+
+  const publishedAt = new Date().toISOString()
+  let parsed
+  try {
+    parsed = await registerRef(c.env, ref, { publishedAt, prUrl })
   } catch (err) {
     throw new HttpError(400, `Invalid or unregisterable ref: ${ref} (${err})`)
   }
-  return c.json({ ref, version: parsed.version, published, registered: register }, 201)
+  return c.json({ ref, version: parsed.version, publishedAt }, 201)
 })
 
 /** List the registered preview refs (the runtime R2 index). Public read. */

--- a/test/worker.test.ts
+++ b/test/worker.test.ts
@@ -140,50 +140,67 @@ afterAll(() => {
   vi.unstubAllGlobals()
 })
 
+// Publish metas + register the ref, the way the CI action does it: one
+// /-/publish for the metas and a final /-/register that makes the versions
+// visible. Returns the register response (the visibility-flipping call).
+async function publishAndRegister(body: {
+  ref: string
+  prUrl?: string
+  packages: Array<Record<string, any>>
+}): Promise<Response> {
+  const headers = {
+    authorization: 'Bearer test-admin-token',
+    'content-type': 'application/json',
+  }
+  const pub = await SELF.fetch(`${BASE}/-/publish`, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({ ref: body.ref, packages: body.packages }),
+  })
+  if (pub.status !== 201) return pub
+  return SELF.fetch(`${BASE}/-/register`, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({ ref: body.ref, prUrl: body.prUrl }),
+  })
+}
+
 // The suite's fixture preview ref (`commit.a832a55`), published before each test
 // (idempotent, so it survives storage isolation). Publishing vite-plus + core
 // with their rewritten package.json is exactly what a CI publish stores, so
-// packuments inject the ref the way they do in production. (`POST /-/refs`
-// register-only was removed; a ref exists only once it has been published.)
+// packuments inject the ref the way they do in production.
 const FIXTURE_VERSION = '0.0.0-commit.a832a55'
 beforeEach(async () => {
-  await SELF.fetch(`${BASE}/-/publish`, {
-    method: 'POST',
-    headers: {
-      authorization: 'Bearer test-admin-token',
-      'content-type': 'application/json',
-    },
-    body: JSON.stringify({
-      ref: 'commit.a832a55',
-      packages: [
-        {
+  await publishAndRegister({
+    ref: 'commit.a832a55',
+    packages: [
+      {
+        name: 'vite-plus',
+        version: FIXTURE_VERSION,
+        packageJson: {
           name: 'vite-plus',
           version: FIXTURE_VERSION,
-          packageJson: {
-            name: 'vite-plus',
-            version: FIXTURE_VERSION,
-            dependencies: { '@voidzero-dev/vite-plus-core': FIXTURE_VERSION },
-            optionalDependencies: {
-              '@voidzero-dev/vite-plus-darwin-arm64': `0.0.0-commit.${PLATFORM_SHA}`,
-            },
-            bin: { vp: './bin/vp' },
+          dependencies: { '@voidzero-dev/vite-plus-core': FIXTURE_VERSION },
+          optionalDependencies: {
+            '@voidzero-dev/vite-plus-darwin-arm64': `0.0.0-commit.${PLATFORM_SHA}`,
           },
-          integrity: 'sha512-Zm9vYmFy',
-          shasum: 'a'.repeat(40),
+          bin: { vp: './bin/vp' },
         },
-        {
+        integrity: 'sha512-Zm9vYmFy',
+        shasum: 'a'.repeat(40),
+      },
+      {
+        name: '@voidzero-dev/vite-plus-core',
+        version: FIXTURE_VERSION,
+        packageJson: {
           name: '@voidzero-dev/vite-plus-core',
           version: FIXTURE_VERSION,
-          packageJson: {
-            name: '@voidzero-dev/vite-plus-core',
-            version: FIXTURE_VERSION,
-            dependencies: { 'vite-plus': FIXTURE_VERSION },
-          },
-          integrity: 'sha512-Y29yZQ',
-          shasum: 'b'.repeat(40),
+          dependencies: { 'vite-plus': FIXTURE_VERSION },
         },
-      ],
-    }),
+        integrity: 'sha512-Y29yZQ',
+        shasum: 'b'.repeat(40),
+      },
+    ],
   })
 })
 
@@ -289,21 +306,17 @@ describe('packument endpoint', () => {
     for (let i = 1; i <= 10; i++) {
       const sha = `f1${String(i).padStart(5, '0')}`
       const ver = `0.0.0-commit.${sha}`
-      const pub = await SELF.fetch(`${BASE}/-/publish`, {
-        method: 'POST',
-        headers: { ...AUTH, 'content-type': 'application/json' },
-        body: JSON.stringify({
-          ref: `commit.${sha}`,
-          packages: [
-            {
-              name: 'vite-plus',
-              version: ver,
-              packageJson: { name: 'vite-plus', version: ver },
-              integrity: `sha512-${sha}`,
-              shasum: sha,
-            },
-          ],
-        }),
+      const pub = await publishAndRegister({
+        ref: `commit.${sha}`,
+        packages: [
+          {
+            name: 'vite-plus',
+            version: ver,
+            packageJson: { name: 'vite-plus', version: ver },
+            integrity: `sha512-${sha}`,
+            shasum: sha,
+          },
+        ],
       })
       expect(pub.status).toBe(201)
       await env.STORAGE.delete(metaKey('vite-plus', ver))
@@ -330,21 +343,17 @@ describe('packument endpoint', () => {
     const ver = `0.0.0-commit.${sha}`
     // Warm the output cache for vite-plus under the current etag.
     await SELF.fetch(`${BASE}/vite-plus`, { headers: { accept: 'application/json' } })
-    const pub = await SELF.fetch(`${BASE}/-/publish`, {
-      method: 'POST',
-      headers: { ...AUTH, 'content-type': 'application/json' },
-      body: JSON.stringify({
-        ref: `commit.${sha}`,
-        packages: [
-          {
-            name: 'vite-plus',
-            version: ver,
-            packageJson: { name: 'vite-plus', version: ver },
-            integrity: 'sha512-f5',
-            shasum: 'f5',
-          },
-        ],
-      }),
+    const pub = await publishAndRegister({
+      ref: `commit.${sha}`,
+      packages: [
+        {
+          name: 'vite-plus',
+          version: ver,
+          packageJson: { name: 'vite-plus', version: ver },
+          integrity: 'sha512-f5',
+          shasum: 'f5',
+        },
+      ],
     })
     expect(pub.status).toBe(201)
     const res = await SELF.fetch(`${BASE}/vite-plus`, {
@@ -360,12 +369,13 @@ describe('packument endpoint', () => {
     const sha = 'feedfacefeedfacefeedfacefeedfacefeedface'
     const ver = `0.0.0-commit.${sha}`
     const before = Date.now()
-    const pub = await SELF.fetch(`${BASE}/-/publish`, {
+    // A client-reported publishedAt in either call must be ignored in favor of
+    // the server's own stamp.
+    const pubMeta = await SELF.fetch(`${BASE}/-/publish`, {
       method: 'POST',
       headers: { ...AUTH, 'content-type': 'application/json' },
       body: JSON.stringify({
         ref: `commit.${sha}`,
-        // A client-reported time must be ignored in favor of the server's.
         publishedAt: '2000-01-01T00:00:00.000Z',
         packages: [
           {
@@ -378,7 +388,16 @@ describe('packument endpoint', () => {
         ],
       }),
     })
-    expect(pub.status).toBe(201)
+    expect(pubMeta.status).toBe(201)
+    const reg = await SELF.fetch(`${BASE}/-/register`, {
+      method: 'POST',
+      headers: { ...AUTH, 'content-type': 'application/json' },
+      body: JSON.stringify({
+        ref: `commit.${sha}`,
+        publishedAt: '2000-01-01T00:00:00.000Z',
+      }),
+    })
+    expect(reg.status).toBe(201)
 
     const timeFor = async () =>
       (
@@ -615,21 +634,17 @@ describe('integrity', () => {
       body: tarball,
     })
     expect(up.status).toBe(201)
-    const pub = await SELF.fetch(`${BASE}/-/publish`, {
-      method: 'POST',
-      headers: { ...AUTH, 'content-type': 'application/json' },
-      body: JSON.stringify({
-        ref: `commit.${PLATFORM_SHA}`,
-        packages: [
-          {
-            name: pkg,
-            version: ver,
-            packageJson: { name: pkg, version: ver, os: ['darwin'], cpu: ['arm64'] },
-            integrity,
-            shasum: '',
-          },
-        ],
-      }),
+    const pub = await publishAndRegister({
+      ref: `commit.${PLATFORM_SHA}`,
+      packages: [
+        {
+          name: pkg,
+          version: ver,
+          packageJson: { name: pkg, version: ver, os: ['darwin'], cpu: ['arm64'] },
+          integrity,
+          shasum: '',
+        },
+      ],
     })
     expect(pub.status).toBe(201)
 
@@ -685,22 +700,18 @@ describe('pkg.pr.new-style download', () => {
   it('redirects /<owner>/<repo>@<pr> to the PR latest commit tarball', async () => {
     const prUrl = 'https://github.com/voidzero-dev/vite-plus/pull/909'
     const publish = (sha: string, version: string) =>
-      SELF.fetch(`${BASE}/-/publish`, {
-        method: 'POST',
-        headers: { ...AUTH, 'content-type': 'application/json' },
-        body: JSON.stringify({
-          ref: `commit.${sha}`,
-          prUrl,
-          packages: [
-            {
-              name: 'vite-plus',
-              version,
-              packageJson: { name: 'vite-plus', version },
-              integrity: 'sha512-test',
-              shasum: '',
-            },
-          ],
-        }),
+      publishAndRegister({
+        ref: `commit.${sha}`,
+        prUrl,
+        packages: [
+          {
+            name: 'vite-plus',
+            version,
+            packageJson: { name: 'vite-plus', version },
+            integrity: 'sha512-test',
+            shasum: '',
+          },
+        ],
       })
     const verB = '0.0.0-commit.ddd9090'
     expect((await publish('ccc9090', '0.0.0-commit.ccc9090')).status).toBe(201)
@@ -739,22 +750,18 @@ describe('pkg.pr.new-style download', () => {
     const prUrl = 'https://github.com/voidzero-dev/vite-plus/pull/808'
     const sha = 'e1e1e10'
     const version = `0.0.0-commit.${sha}`
-    const pub = await SELF.fetch(`${BASE}/-/publish`, {
-      method: 'POST',
-      headers: { ...AUTH, 'content-type': 'application/json' },
-      body: JSON.stringify({
-        ref: `commit.${sha}`,
-        prUrl,
-        packages: [
-          {
-            name: 'vite-plus',
-            version,
-            packageJson: { name: 'vite-plus', version },
-            integrity: 'sha512-test',
-            shasum: '',
-          },
-        ],
-      }),
+    const pub = await publishAndRegister({
+      ref: `commit.${sha}`,
+      prUrl,
+      packages: [
+        {
+          name: 'vite-plus',
+          version,
+          packageJson: { name: 'vite-plus', version },
+          integrity: 'sha512-test',
+          shasum: '',
+        },
+      ],
     })
     expect(pub.status).toBe(201)
     const res = await SELF.fetch(`${BASE}/voidzero-dev/vite-plus@808`, {
@@ -814,22 +821,18 @@ describe('admin: refs', () => {
     const sha = 'deadbee'
     const version = `0.0.0-commit.${sha}`
     const prUrl = 'https://github.com/voidzero-dev/vite-plus/pull/123'
-    const pub = await SELF.fetch(`${BASE}/-/publish`, {
-      method: 'POST',
-      headers: { ...AUTH, 'content-type': 'application/json' },
-      body: JSON.stringify({
-        ref: `commit.${sha}`,
-        prUrl,
-        packages: [
-          {
-            name: 'vite-plus',
-            version,
-            packageJson: { name: 'vite-plus', version },
-            integrity: 'sha512-test',
-            shasum: '',
-          },
-        ],
-      }),
+    const pub = await publishAndRegister({
+      ref: `commit.${sha}`,
+      prUrl,
+      packages: [
+        {
+          name: 'vite-plus',
+          version,
+          packageJson: { name: 'vite-plus', version },
+          integrity: 'sha512-test',
+          shasum: '',
+        },
+      ],
     })
     expect(pub.status).toBe(201)
 
@@ -862,21 +865,17 @@ describe('admin: refs', () => {
   it('omits the PR url for a ref published without one (push run)', async () => {
     const sha = 'beefca0'
     const version = `0.0.0-commit.${sha}`
-    const pub = await SELF.fetch(`${BASE}/-/publish`, {
-      method: 'POST',
-      headers: { ...AUTH, 'content-type': 'application/json' },
-      body: JSON.stringify({
-        ref: `commit.${sha}`,
-        packages: [
-          {
-            name: 'vite-plus',
-            version,
-            packageJson: { name: 'vite-plus', version },
-            integrity: 'sha512-test',
-            shasum: '',
-          },
-        ],
-      }),
+    const pub = await publishAndRegister({
+      ref: `commit.${sha}`,
+      packages: [
+        {
+          name: 'vite-plus',
+          version,
+          packageJson: { name: 'vite-plus', version },
+          integrity: 'sha512-test',
+          shasum: '',
+        },
+      ],
     })
     expect(pub.status).toBe(201)
 
@@ -899,22 +898,18 @@ describe('admin: refs', () => {
   it('injects a mutable pr-<n> dist-tag pointing at the PR latest commit', async () => {
     const prUrl = 'https://github.com/voidzero-dev/vite-plus/pull/777'
     const publish = (sha: string, version: string) =>
-      SELF.fetch(`${BASE}/-/publish`, {
-        method: 'POST',
-        headers: { ...AUTH, 'content-type': 'application/json' },
-        body: JSON.stringify({
-          ref: `commit.${sha}`,
-          prUrl,
-          packages: [
-            {
-              name: 'vite-plus',
-              version,
-              packageJson: { name: 'vite-plus', version },
-              integrity: 'sha512-test',
-              shasum: '',
-            },
-          ],
-        }),
+      publishAndRegister({
+        ref: `commit.${sha}`,
+        prUrl,
+        packages: [
+          {
+            name: 'vite-plus',
+            version,
+            packageJson: { name: 'vite-plus', version },
+            integrity: 'sha512-test',
+            shasum: '',
+          },
+        ],
       })
     const verA = '0.0.0-commit.aaa7770'
     const verB = '0.0.0-commit.bbb7770'
@@ -956,23 +951,20 @@ describe('admin: refs', () => {
 
   it('publishes concurrently without overwriting (incremental)', async () => {
     const publish = (sha: string) =>
-      SELF.fetch(`${BASE}/-/publish`, {
-        method: 'POST',
-        headers: { ...AUTH, 'content-type': 'application/json' },
-        body: JSON.stringify({
-          ref: `commit.${sha}`,
-          packages: [
-            {
-              name: 'vite-plus',
-              version: `0.0.0-commit.${sha}`,
-              packageJson: { name: 'vite-plus', version: `0.0.0-commit.${sha}` },
-              integrity: 'sha512-x',
-              shasum: 'x',
-            },
-          ],
-        }),
+      publishAndRegister({
+        ref: `commit.${sha}`,
+        packages: [
+          {
+            name: 'vite-plus',
+            version: `0.0.0-commit.${sha}`,
+            packageJson: { name: 'vite-plus', version: `0.0.0-commit.${sha}` },
+            integrity: 'sha512-x',
+            shasum: 'x',
+          },
+        ],
       })
-    // Two PRs publishing at the same time: both refs must survive the CAS.
+    // Two PRs publishing at the same time: both refs must survive the CAS
+    // (the refs-index compare-and-swap runs at /-/register).
     await Promise.all([publish('aaaaaaa'), publish('bbbbbbb')])
     const list = (await (
       await SELF.fetch(`${BASE}/-/refs`)
@@ -1062,12 +1054,8 @@ describe('admin: publish', () => {
     expect(res.status).toBe(401)
   })
 
-  it('stores meta, registers the ref, and injects it into the packument', async () => {
-    const res = await SELF.fetch(`${BASE}/-/publish`, {
-      method: 'POST',
-      headers: { ...AUTH, 'content-type': 'application/json' },
-      body: JSON.stringify(body),
-    })
+  it('stores meta and, once registered, injects it into the packument', async () => {
+    const res = await publishAndRegister(body)
     expect(res.status).toBe(201)
     expect(await res.json()).toMatchObject({ ref: 'commit.f00dface', version: ver })
 
@@ -1090,11 +1078,11 @@ describe('admin: publish', () => {
 })
 
 describe('admin: per-package atomic publish', () => {
-  // The publish action uploads each tarball and publishes its meta immediately
-  // (register: false), then registers the ref once at the end (packages: []).
-  // A cancelled run can then never leave tarball bytes visible without their
-  // matching meta: metas travel with bytes, and visibility flips atomically at
-  // the final register call.
+  // The publish action uploads each tarball and publishes its meta immediately,
+  // then registers the ref once at the end via the dedicated /-/register
+  // endpoint. A cancelled run can then never leave tarball bytes visible
+  // without their matching meta: metas travel with bytes, and visibility flips
+  // atomically at the final register call.
   const sha = 'abc1234'
   const ver = `0.0.0-commit.${sha}`
   const pkg = {
@@ -1105,20 +1093,19 @@ describe('admin: per-package atomic publish', () => {
     shasum: 'a1'.repeat(20),
   }
 
-  const publish = (body: Record<string, any>) =>
-    SELF.fetch(`${BASE}/-/publish`, {
+  const post = (path: string, body: Record<string, any>, withAuth = true) =>
+    SELF.fetch(`${BASE}${path}`, {
       method: 'POST',
-      headers: { ...AUTH, 'content-type': 'application/json' },
+      headers: { ...(withAuth ? AUTH : {}), 'content-type': 'application/json' },
       body: JSON.stringify(body),
     })
 
-  it('register:false stores the meta without registering the ref; a final packages-empty call registers it', async () => {
-    // Phase 1: meta-only publish.
-    const res1 = await publish({ ref: `commit.${sha}`, register: false, packages: [pkg] })
+  it('publish stores the meta without registering; /-/register flips visibility', async () => {
+    // Phase 1: meta-only publish (registration is not publish's job).
+    const res1 = await post('/-/publish', { ref: `commit.${sha}`, packages: [pkg] })
     expect(res1.status).toBe(201)
-    expect(await res1.json()).toMatchObject({ registered: false })
 
-    // Meta and index are written...
+    // Meta is written...
     const meta = (await (await env.STORAGE.get(metaKey('vite-plus', ver)))!.json()) as Record<string, any>
     expect(meta.integrity).toBe('sha512-atomic')
 
@@ -1130,10 +1117,10 @@ describe('admin: per-package atomic publish', () => {
     ).json()) as Record<string, any>
     expect(pack1.versions[ver]).toBeUndefined()
 
-    // Phase 2: register-only call (empty packages) flips visibility.
-    const res2 = await publish({ ref: `commit.${sha}`, packages: [] })
+    // Phase 2: the dedicated register call flips visibility.
+    const res2 = await post('/-/register', { ref: `commit.${sha}` })
     expect(res2.status).toBe(201)
-    expect(await res2.json()).toMatchObject({ registered: true })
+    expect(await res2.json()).toMatchObject({ ref: `commit.${sha}`, version: ver })
 
     const refs2 = (await (await SELF.fetch(`${BASE}/-/refs`)).json()) as Record<string, any>
     expect(refs2.refs.some((r: any) => r.ref === `commit.${sha}`)).toBe(true)
@@ -1143,9 +1130,28 @@ describe('admin: per-package atomic publish', () => {
     expect(pack2.versions[ver]?.dist?.integrity).toBe('sha512-atomic')
   })
 
-  it('rejects a register:false call with no packages (would be a no-op)', async () => {
-    const res = await publish({ ref: `commit.${sha}`, register: false, packages: [] })
+  it('publish rejects an empty packages list (registration lives on /-/register)', async () => {
+    const res = await post('/-/publish', { ref: `commit.${sha}`, packages: [] })
     expect(res.status).toBe(400)
+  })
+
+  it('register requires auth and a valid commit ref', async () => {
+    expect((await post('/-/register', { ref: `commit.${sha}` }, false)).status).toBe(401)
+    expect((await post('/-/register', { ref: 'pr.123' })).status).toBe(400)
+    expect((await post('/-/register', {})).status).toBe(400)
+  })
+
+  it('register records the prUrl and publish time', async () => {
+    await post('/-/publish', { ref: `commit.${sha}`, packages: [pkg] })
+    const res = await post('/-/register', {
+      ref: `commit.${sha}`,
+      prUrl: 'https://github.com/voidzero-dev/vite-plus/pull/1891',
+    })
+    expect(res.status).toBe(201)
+    const refs = (await (await SELF.fetch(`${BASE}/-/refs`)).json()) as Record<string, any>
+    const entry = refs.refs.find((r: any) => r.ref === `commit.${sha}`)
+    expect(entry.prUrl).toBe('https://github.com/voidzero-dev/vite-plus/pull/1891')
+    expect(entry.publishedAt).toBeTruthy()
   })
 })
 


### PR DESCRIPTION
## Summary
Follow-up to #52: the `register` boolean made `/-/publish` do two jobs. Now:

- `POST /-/publish {ref, packages}`: stores metas only, never registers. An empty `packages` is always a 400.
- `POST /-/register {ref, prUrl?}` (new): registers the ref, making its published versions visible; stamps `publishedAt` at the moment the release actually becomes installable.

The action's final call moves to `/-/register`; its per-package publish calls just drop the flag. Docs updated.

## BREAKING: coordinate the deploy with a pin bump
`/-/publish` no longer registers, so any action pinned to an older commit (vite-plus currently pins `f867796`) will store artifacts but never make a NEW sha visible after this deploys. Merge order:

1. Merge + deploy this PR
2. Immediately bump the vite-plus pin in `publish-to-pkg.pr.new.yml` to this merge commit

(Re-publishes of already-registered shas keep working in the gap; only brand-new shas are affected.)

## Test plan
- [x] Failing-first tests for the new endpoint (auth, validation, visibility flip, prUrl/publishedAt recording)
- [x] All publish call sites in the suite converted to the two-call protocol; 83/83 passing
- [x] `pnpm typecheck`, action bundle rebuilt