### PR TITLE
Smoke-test the admin write lifecycle (publish → register → serve → integrity) on staging

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -36,8 +36,13 @@ jobs:
         env:
           VOID_TOKEN: ${{ secrets.VOID_TOKEN }}
 
+      # SMOKE_ADMIN_TOKEN runs the admin write lifecycle against staging only;
+      # production smoke (below) never gets it, so no test artifacts are ever
+      # written to the live bridge.
       - name: Smoke-test staging
         run: node scripts/smoke-test.mjs https://pkg-pr-registry-bridge-staging.void.app
+        env:
+          SMOKE_ADMIN_TOKEN: ${{ secrets.STAGING_ADMIN_TOKEN }}
 
       # Only reached when the staging smoke test passed.
       - name: Deploy to production
@@ -48,5 +53,6 @@ jobs:
           # gitignored, so there is nothing to resolve from in CI.
           VOID_PROJECT: pkg-pr-registry-bridge
 
+      # Read-only: no SMOKE_ADMIN_TOKEN, so the write lifecycle is skipped.
       - name: Smoke-test production
         run: node scripts/smoke-test.mjs https://registry-bridge.viteplus.dev

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -36,11 +36,10 @@ jobs:
         env:
           VOID_TOKEN: ${{ secrets.VOID_TOKEN }}
 
-      # SMOKE_ADMIN_TOKEN runs the admin write lifecycle against staging only;
-      # production smoke (below) never gets it, so no test artifacts are ever
-      # written to the live bridge.
+      # --write runs the admin write lifecycle too (see scripts/smoke-test.mjs
+      # header); staging only, production smoke below stays read-only.
       - name: Smoke-test staging
-        run: node scripts/smoke-test.mjs https://pkg-pr-registry-bridge-staging.void.app
+        run: node scripts/smoke-test.mjs https://pkg-pr-registry-bridge-staging.void.app --write
         env:
           SMOKE_ADMIN_TOKEN: ${{ secrets.STAGING_ADMIN_TOKEN }}
 
@@ -53,6 +52,6 @@ jobs:
           # gitignored, so there is nothing to resolve from in CI.
           VOID_PROJECT: pkg-pr-registry-bridge
 
-      # Read-only: no SMOKE_ADMIN_TOKEN, so the write lifecycle is skipped.
+      # No --write: read-only against the live bridge.
       - name: Smoke-test production
         run: node scripts/smoke-test.mjs https://registry-bridge.viteplus.dev

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -39,5 +39,12 @@ jobs:
         env:
           VOID_TOKEN: ${{ secrets.VOID_TOKEN }}
 
+      # SMOKE_ADMIN_TOKEN enables the admin write lifecycle checks (publish ->
+      # register -> serve -> integrity) against the real staging runtime, the
+      # path two production incidents broke while unit tests stayed green. It is
+      # the staging bridge's ADMIN_TOKEN; production smoke never receives it, so
+      # the write flow only ever runs against disposable staging.
       - name: Smoke-test staging
         run: node scripts/smoke-test.mjs https://pkg-pr-registry-bridge-staging.void.app
+        env:
+          SMOKE_ADMIN_TOKEN: ${{ secrets.STAGING_ADMIN_TOKEN }}

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -39,12 +39,9 @@ jobs:
         env:
           VOID_TOKEN: ${{ secrets.VOID_TOKEN }}
 
-      # SMOKE_ADMIN_TOKEN enables the admin write lifecycle checks (publish ->
-      # register -> serve -> integrity) against the real staging runtime, the
-      # path two production incidents broke while unit tests stayed green. It is
-      # the staging bridge's ADMIN_TOKEN; production smoke never receives it, so
-      # the write flow only ever runs against disposable staging.
+      # --write runs the admin write lifecycle too (see scripts/smoke-test.mjs
+      # header); staging only, and it fails loudly if the token secret is missing.
       - name: Smoke-test staging
-        run: node scripts/smoke-test.mjs https://pkg-pr-registry-bridge-staging.void.app
+        run: node scripts/smoke-test.mjs https://pkg-pr-registry-bridge-staging.void.app --write
         env:
           SMOKE_ADMIN_TOKEN: ${{ secrets.STAGING_ADMIN_TOKEN }}

--- a/scripts/smoke-test.mjs
+++ b/scripts/smoke-test.mjs
@@ -4,29 +4,38 @@
 // while all unit tests passed). Run it against staging before promoting to
 // production.
 //
-//   node scripts/smoke-test.mjs https://pkg-pr-registry-bridge-staging.void.app
+//   node scripts/smoke-test.mjs <base-url> [--write]
 //
 // Each check prints the actual response (status + key fields/headers) BEFORE
 // asserting, so a failure is debuggable straight from the CI log.
 //
-// When SMOKE_ADMIN_TOKEN is set (staging only, never production), it also runs
-// the full admin write lifecycle end-to-end against the real runtime: upload a
-// tarball, publish its meta, assert the version is NOT served until the ref is
+// `--write` (staging only, never production) additionally runs the full admin
+// write lifecycle end-to-end against the real runtime: upload a tarball,
+// publish its meta, assert the version is NOT served until the ref is
 // registered, register it, then assert the packument advertises an integrity
 // that matches the exact served tarball bytes. This is the publish -> register
 // -> serve -> integrity path that two production incidents broke while every
-// unit test stayed green; it self-cleans by purging the artifact afterward.
+// unit test stayed green; it self-cleans by purging (and unregistering) the
+// artifact afterward. The flag is explicit so a missing SMOKE_ADMIN_TOKEN
+// fails loudly instead of silently skipping the coverage.
 
 import { createTarGzip } from 'nanotar'
 import { createHash } from 'node:crypto'
+import { refToVersion } from './lib/config.mjs'
 
-const base = (process.argv[2] || '').replace(/\/+$/, '')
+const args = process.argv.slice(2)
+const WRITE = args.includes('--write')
+const base = (args.find((a) => !a.startsWith('--')) ?? '').replace(/\/+$/, '')
 if (!base) {
-  console.error('usage: node scripts/smoke-test.mjs <base-url>')
+  console.error('usage: node scripts/smoke-test.mjs <base-url> [--write]')
   process.exit(2)
 }
 
-const ADMIN_TOKEN = process.env.SMOKE_ADMIN_TOKEN || ''
+const ADMIN_TOKEN = process.env.SMOKE_ADMIN_TOKEN
+if (WRITE && !ADMIN_TOKEN) {
+  console.error('--write requires SMOKE_ADMIN_TOKEN (the deployment\'s ADMIN_TOKEN)')
+  process.exit(2)
+}
 
 // Any valid commit sha: the download/HEAD checks resolve a sha to its synthetic
 // version without a registry lookup, so this need not be a registered ref. The
@@ -38,6 +47,104 @@ const truncate = (s, n = 300) => (s.length > n ? `${s.slice(0, n)}…` : s)
 
 function assert(cond, msg) {
   if (!cond) throw new Error(msg)
+}
+
+// npm dist.integrity SRI from tarball bytes.
+const sri = (buf) => `sha512-${createHash('sha512').update(buf).digest('base64')}`
+
+const postJson = (path, body) =>
+  fetch(`${base}${path}`, {
+    method: 'POST',
+    headers: {
+      authorization: `Bearer ${ADMIN_TOKEN}`,
+      'content-type': 'application/json',
+    },
+    body: JSON.stringify(body),
+  })
+
+/**
+ * The full admin write lifecycle against the real runtime. Uses a unique,
+ * clearly-labelled `e2e` commit sha per run so it never collides with real
+ * refs, and purges + unregisters the artifact at the end.
+ */
+async function runAdminLifecycle() {
+  const name = 'vite-plus'
+  // Unique per run, valid [0-9a-f]{7,40}, recognizable as a smoke artifact.
+  const ref = `commit.e2e${Date.now().toString(16)}`
+  const version = refToVersion(ref)
+
+  // Build a real, valid preview tarball and derive its integrity from the exact
+  // bytes we upload, the same way CI's publish action does.
+  const tarball = await createTarGzip([
+    { name: 'package/package.json', data: JSON.stringify({ name, version }) },
+    { name: 'package/index.js', data: 'export const smoke = true\n' },
+  ])
+  const integrity = sri(tarball)
+
+  const fetchDist = async () => {
+    const res = await fetch(`${base}/${name}`, {
+      headers: { accept: 'application/vnd.npm.install-v1+json' },
+    })
+    const body = await res.json()
+    return body?.versions?.[version]?.dist ?? null
+  }
+
+  try {
+    // 1. Upload the tarball bytes (worker streams them straight into R2).
+    const up = await fetch(`${base}/-/tarball/${name}/${version}.tgz`, {
+      method: 'PUT',
+      headers: { authorization: `Bearer ${ADMIN_TOKEN}`, 'content-type': 'application/gzip' },
+      body: tarball,
+    })
+    console.log(`    PUT tarball -> ${up.status}`)
+    assert(up.status === 201, `upload status ${up.status}`)
+
+    // 2. Publish the meta. This must NOT make the version visible on its own.
+    const shasum = createHash('sha1').update(tarball).digest('hex')
+    const pub = await postJson('/-/publish', {
+      ref,
+      packages: [{ name, version, packageJson: { name, version }, integrity, shasum }],
+    })
+    console.log(`    POST /-/publish -> ${pub.status}`)
+    assert(pub.status === 201, `publish status ${pub.status}`)
+
+    // 3. The atomic gate: an unregistered version is invisible in the packument.
+    const beforeRegister = await fetchDist()
+    console.log(`    packument before register: ${beforeRegister ? 'PRESENT (bug)' : 'absent'}`)
+    assert(!beforeRegister, 'version visible before /-/register (atomic gate broken)')
+
+    // 4. Register the ref: flips the version visible.
+    const reg = await postJson('/-/register', { ref })
+    console.log(`    POST /-/register -> ${reg.status}`)
+    assert(reg.status === 201, `register status ${reg.status}`)
+
+    // 5. Now it is served, and its advertised integrity must match the bytes
+    // (the invariant both production incidents violated).
+    const dist = await fetchDist()
+    console.log(`    packument after register: integrity=${dist?.integrity?.slice(0, 20)}…`)
+    assert(dist, 'version absent from packument after register')
+    assert(dist.integrity === integrity, 'packument integrity != uploaded integrity')
+
+    // 6. Fetch the actually-served tarball from the runtime under test and
+    // confirm its bytes hash to the advertised integrity (catches a stale or
+    // mismatched served body directly). Use dist.tarball's PATH against `base`
+    // rather than its absolute URL: a staging deploy sets PUBLIC_BASE_URL to
+    // the production host, so dist.tarball points at prod, where this staging
+    // artifact does not exist. We want to verify the bytes THIS runtime serves.
+    assert(dist.tarball, 'no dist.tarball in packument')
+    const tarUrl = `${base}${new URL(dist.tarball).pathname}`
+    const tres = await fetch(tarUrl)
+    const served = new Uint8Array(await tres.arrayBuffer())
+    const servedIntegrity = sri(served)
+    console.log(`    GET ${tarUrl} -> ${tres.status}, served integrity=${servedIntegrity.slice(0, 20)}…`)
+    assert(tres.status === 200, `served tarball status ${tres.status}`)
+    assert(servedIntegrity === integrity, 'served tarball bytes != advertised integrity')
+  } finally {
+    // Fully clean up: unregister too, or every run leaks a registered e2e ref
+    // into /-/refs (and packument rebuilds) until the 90-day TTL.
+    const p = await postJson('/-/purge', { package: name, version, unregister: true }).catch(() => null)
+    console.log(`    cleanup: purge+unregister -> ${p ? p.status : 'error (ignored)'}`)
+  }
 }
 
 const checks = [
@@ -115,6 +222,18 @@ const checks = [
   },
 ]
 
+if (WRITE) {
+  // Not retried (`retry: false`): a retry after a partial run would false-fail
+  // the "invisible before register" gate, and the sha is unique per run anyway.
+  checks.push({
+    name: 'admin publish -> register -> serve -> integrity (lifecycle)',
+    retry: false,
+    run: runAdminLifecycle,
+  })
+} else {
+  console.log('read-only mode (pass --write to include the admin lifecycle)')
+}
+
 console.log(`smoke-testing ${base}`)
 
 // Retry each check until it passes or a shared deadline, to ride out edge
@@ -141,7 +260,7 @@ async function runWithRetry(check) {
 let failed = 0
 for (const check of checks) {
   try {
-    await runWithRetry(check)
+    await (check.retry === false ? check.run() : runWithRetry(check))
     console.log(`  ✓ ${check.name}`)
   } catch (err) {
     console.error(`  ✗ ${check.name}: ${err.message}`)
@@ -149,128 +268,8 @@ for (const check of checks) {
   }
 }
 
-// npm dist.integrity SRI from tarball bytes.
-const sri = (buf) => `sha512-${createHash('sha512').update(buf).digest('base64')}`
-const shasum = (buf) => createHash('sha1').update(buf).digest('hex')
-
-/**
- * Exercise the full admin write lifecycle against the real runtime. Gated on
- * SMOKE_ADMIN_TOKEN so it runs on staging (token set) and is skipped on
- * production (no token) and on fork PRs (no secret access). Uses a unique,
- * clearly-labelled `e2e` commit sha per run so it never collides with real
- * refs, and purges the artifact at the end.
- */
-async function runAdminLifecycle() {
-  const auth = {
-    authorization: `Bearer ${ADMIN_TOKEN}`,
-    'content-type': 'application/json',
-  }
-  const name = 'vite-plus'
-  // Unique per run, valid [0-9a-f]{7,40}, recognizable as a smoke artifact.
-  const smokeSha = `e2e${Date.now().toString(16)}`
-  const version = `0.0.0-commit.${smokeSha}`
-
-  // Build a real, valid preview tarball and derive its integrity from the exact
-  // bytes we upload, the same way CI's publish action does.
-  const tarball = await createTarGzip([
-    {
-      name: 'package/package.json',
-      data: JSON.stringify({ name, version }),
-    },
-    { name: 'package/index.js', data: 'export const smoke = true\n' },
-  ])
-  const integrity = sri(tarball)
-
-  const packumentHas = async () => {
-    const res = await fetch(`${base}/${name}`, {
-      headers: { accept: 'application/vnd.npm.install-v1+json' },
-    })
-    const body = await res.json()
-    return body?.versions?.[version]?.dist ?? null
-  }
-
-  try {
-    // 1. Upload the tarball bytes (worker streams them straight into R2).
-    const up = await fetch(`${base}/-/tarball/${name}/${version}.tgz`, {
-      method: 'PUT',
-      headers: { authorization: `Bearer ${ADMIN_TOKEN}`, 'content-type': 'application/gzip' },
-      body: tarball,
-    })
-    console.log(`    PUT tarball -> ${up.status}`)
-    assert(up.status === 201, `upload status ${up.status}`)
-
-    // 2. Publish the meta. This must NOT make the version visible on its own.
-    const pub = await fetch(`${base}/-/publish`, {
-      method: 'POST',
-      headers: auth,
-      body: JSON.stringify({
-        ref: `commit.${smokeSha}`,
-        packages: [{ name, version, packageJson: { name, version }, integrity, shasum: shasum(tarball) }],
-      }),
-    })
-    console.log(`    POST /-/publish -> ${pub.status}`)
-    assert(pub.status === 201, `publish status ${pub.status}`)
-
-    // 3. The atomic gate: an unregistered version is invisible in the packument.
-    const beforeRegister = await packumentHas()
-    console.log(`    packument before register: ${beforeRegister ? 'PRESENT (bug)' : 'absent'}`)
-    assert(!beforeRegister, 'version visible before /-/register (atomic gate broken)')
-
-    // 4. Register the ref: flips the version visible.
-    const reg = await fetch(`${base}/-/register`, {
-      method: 'POST',
-      headers: auth,
-      body: JSON.stringify({ ref: `commit.${smokeSha}` }),
-    })
-    console.log(`    POST /-/register -> ${reg.status}`)
-    assert(reg.status === 201, `register status ${reg.status}`)
-
-    // 5. Now it is served, and its advertised integrity must match the bytes
-    // (the invariant both production incidents violated).
-    const dist = await packumentHas()
-    console.log(`    packument after register: integrity=${dist?.integrity?.slice(0, 20)}…`)
-    assert(dist, 'version absent from packument after register')
-    assert(dist.integrity === integrity, `packument integrity != uploaded integrity`)
-
-    // 6. Fetch the actually-served tarball from the runtime under test and
-    // confirm its bytes hash to the advertised integrity (catches a stale or
-    // mismatched served body directly). Use dist.tarball's PATH against `base`
-    // rather than its absolute URL: a staging deploy sets PUBLIC_BASE_URL to
-    // the production host, so dist.tarball points at prod, where this staging
-    // artifact does not exist. We want to verify the bytes THIS runtime serves.
-    assert(dist.tarball, 'no dist.tarball in packument')
-    const tarUrl = `${base}${new URL(dist.tarball).pathname}`
-    const tres = await fetch(tarUrl)
-    const served = new Uint8Array(await tres.arrayBuffer())
-    const servedIntegrity = sri(served)
-    console.log(`    GET ${tarUrl} -> ${tres.status}, served integrity=${servedIntegrity.slice(0, 20)}…`)
-    assert(tres.status === 200, `served tarball status ${tres.status}`)
-    assert(servedIntegrity === integrity, 'served tarball bytes != advertised integrity')
-  } finally {
-    const p = await fetch(`${base}/-/purge`, {
-      method: 'POST',
-      headers: auth,
-      body: JSON.stringify({ package: name, version }),
-    }).catch(() => null)
-    console.log(`    cleanup: purge -> ${p ? p.status : 'error (ignored)'}`)
-  }
-}
-
-if (ADMIN_TOKEN) {
-  const name = 'admin publish -> register -> serve -> integrity (lifecycle)'
-  try {
-    await runAdminLifecycle()
-    console.log(`  ✓ ${name}`)
-  } catch (err) {
-    console.error(`  ✗ ${name}: ${err.message}`)
-    failed++
-  }
-} else {
-  console.log('  - admin lifecycle skipped (SMOKE_ADMIN_TOKEN not set)')
-}
-
 if (failed > 0) {
   console.error(`\n${failed} smoke check(s) failed against ${base}`)
   process.exit(1)
 }
-console.log(`\nall smoke checks passed against ${base}`)
+console.log(`\nall ${checks.length} smoke checks passed against ${base}`)

--- a/scripts/smoke-test.mjs
+++ b/scripts/smoke-test.mjs
@@ -232,12 +232,18 @@ async function runAdminLifecycle() {
     assert(dist, 'version absent from packument after register')
     assert(dist.integrity === integrity, `packument integrity != uploaded integrity`)
 
-    // 6. Fetch the actually-served tarball and confirm its bytes hash to the
-    // advertised integrity (catches a stale/mismatched served body directly).
-    const tres = await fetch(dist.tarball)
+    // 6. Fetch the actually-served tarball from the runtime under test and
+    // confirm its bytes hash to the advertised integrity (catches a stale or
+    // mismatched served body directly). Use dist.tarball's PATH against `base`
+    // rather than its absolute URL: a staging deploy sets PUBLIC_BASE_URL to
+    // the production host, so dist.tarball points at prod, where this staging
+    // artifact does not exist. We want to verify the bytes THIS runtime serves.
+    assert(dist.tarball, 'no dist.tarball in packument')
+    const tarUrl = `${base}${new URL(dist.tarball).pathname}`
+    const tres = await fetch(tarUrl)
     const served = new Uint8Array(await tres.arrayBuffer())
     const servedIntegrity = sri(served)
-    console.log(`    GET ${dist.tarball} -> ${tres.status}, served integrity=${servedIntegrity.slice(0, 20)}…`)
+    console.log(`    GET ${tarUrl} -> ${tres.status}, served integrity=${servedIntegrity.slice(0, 20)}…`)
     assert(tres.status === 200, `served tarball status ${tres.status}`)
     assert(servedIntegrity === integrity, 'served tarball bytes != advertised integrity')
   } finally {

--- a/scripts/smoke-test.mjs
+++ b/scripts/smoke-test.mjs
@@ -8,12 +8,25 @@
 //
 // Each check prints the actual response (status + key fields/headers) BEFORE
 // asserting, so a failure is debuggable straight from the CI log.
+//
+// When SMOKE_ADMIN_TOKEN is set (staging only, never production), it also runs
+// the full admin write lifecycle end-to-end against the real runtime: upload a
+// tarball, publish its meta, assert the version is NOT served until the ref is
+// registered, register it, then assert the packument advertises an integrity
+// that matches the exact served tarball bytes. This is the publish -> register
+// -> serve -> integrity path that two production incidents broke while every
+// unit test stayed green; it self-cleans by purging the artifact afterward.
+
+import { createTarGzip } from 'nanotar'
+import { createHash } from 'node:crypto'
 
 const base = (process.argv[2] || '').replace(/\/+$/, '')
 if (!base) {
   console.error('usage: node scripts/smoke-test.mjs <base-url>')
   process.exit(2)
 }
+
+const ADMIN_TOKEN = process.env.SMOKE_ADMIN_TOKEN || ''
 
 // Any valid commit sha: the download/HEAD checks resolve a sha to its synthetic
 // version without a registry lookup, so this need not be a registered ref. The
@@ -136,8 +149,122 @@ for (const check of checks) {
   }
 }
 
+// npm dist.integrity SRI from tarball bytes.
+const sri = (buf) => `sha512-${createHash('sha512').update(buf).digest('base64')}`
+const shasum = (buf) => createHash('sha1').update(buf).digest('hex')
+
+/**
+ * Exercise the full admin write lifecycle against the real runtime. Gated on
+ * SMOKE_ADMIN_TOKEN so it runs on staging (token set) and is skipped on
+ * production (no token) and on fork PRs (no secret access). Uses a unique,
+ * clearly-labelled `e2e` commit sha per run so it never collides with real
+ * refs, and purges the artifact at the end.
+ */
+async function runAdminLifecycle() {
+  const auth = {
+    authorization: `Bearer ${ADMIN_TOKEN}`,
+    'content-type': 'application/json',
+  }
+  const name = 'vite-plus'
+  // Unique per run, valid [0-9a-f]{7,40}, recognizable as a smoke artifact.
+  const smokeSha = `e2e${Date.now().toString(16)}`
+  const version = `0.0.0-commit.${smokeSha}`
+
+  // Build a real, valid preview tarball and derive its integrity from the exact
+  // bytes we upload, the same way CI's publish action does.
+  const tarball = await createTarGzip([
+    {
+      name: 'package/package.json',
+      data: JSON.stringify({ name, version }),
+    },
+    { name: 'package/index.js', data: 'export const smoke = true\n' },
+  ])
+  const integrity = sri(tarball)
+
+  const packumentHas = async () => {
+    const res = await fetch(`${base}/${name}`, {
+      headers: { accept: 'application/vnd.npm.install-v1+json' },
+    })
+    const body = await res.json()
+    return body?.versions?.[version]?.dist ?? null
+  }
+
+  try {
+    // 1. Upload the tarball bytes (worker streams them straight into R2).
+    const up = await fetch(`${base}/-/tarball/${name}/${version}.tgz`, {
+      method: 'PUT',
+      headers: { authorization: `Bearer ${ADMIN_TOKEN}`, 'content-type': 'application/gzip' },
+      body: tarball,
+    })
+    console.log(`    PUT tarball -> ${up.status}`)
+    assert(up.status === 201, `upload status ${up.status}`)
+
+    // 2. Publish the meta. This must NOT make the version visible on its own.
+    const pub = await fetch(`${base}/-/publish`, {
+      method: 'POST',
+      headers: auth,
+      body: JSON.stringify({
+        ref: `commit.${smokeSha}`,
+        packages: [{ name, version, packageJson: { name, version }, integrity, shasum: shasum(tarball) }],
+      }),
+    })
+    console.log(`    POST /-/publish -> ${pub.status}`)
+    assert(pub.status === 201, `publish status ${pub.status}`)
+
+    // 3. The atomic gate: an unregistered version is invisible in the packument.
+    const beforeRegister = await packumentHas()
+    console.log(`    packument before register: ${beforeRegister ? 'PRESENT (bug)' : 'absent'}`)
+    assert(!beforeRegister, 'version visible before /-/register (atomic gate broken)')
+
+    // 4. Register the ref: flips the version visible.
+    const reg = await fetch(`${base}/-/register`, {
+      method: 'POST',
+      headers: auth,
+      body: JSON.stringify({ ref: `commit.${smokeSha}` }),
+    })
+    console.log(`    POST /-/register -> ${reg.status}`)
+    assert(reg.status === 201, `register status ${reg.status}`)
+
+    // 5. Now it is served, and its advertised integrity must match the bytes
+    // (the invariant both production incidents violated).
+    const dist = await packumentHas()
+    console.log(`    packument after register: integrity=${dist?.integrity?.slice(0, 20)}…`)
+    assert(dist, 'version absent from packument after register')
+    assert(dist.integrity === integrity, `packument integrity != uploaded integrity`)
+
+    // 6. Fetch the actually-served tarball and confirm its bytes hash to the
+    // advertised integrity (catches a stale/mismatched served body directly).
+    const tres = await fetch(dist.tarball)
+    const served = new Uint8Array(await tres.arrayBuffer())
+    const servedIntegrity = sri(served)
+    console.log(`    GET ${dist.tarball} -> ${tres.status}, served integrity=${servedIntegrity.slice(0, 20)}…`)
+    assert(tres.status === 200, `served tarball status ${tres.status}`)
+    assert(servedIntegrity === integrity, 'served tarball bytes != advertised integrity')
+  } finally {
+    const p = await fetch(`${base}/-/purge`, {
+      method: 'POST',
+      headers: auth,
+      body: JSON.stringify({ package: name, version }),
+    }).catch(() => null)
+    console.log(`    cleanup: purge -> ${p ? p.status : 'error (ignored)'}`)
+  }
+}
+
+if (ADMIN_TOKEN) {
+  const name = 'admin publish -> register -> serve -> integrity (lifecycle)'
+  try {
+    await runAdminLifecycle()
+    console.log(`  ✓ ${name}`)
+  } catch (err) {
+    console.error(`  ✗ ${name}: ${err.message}`)
+    failed++
+  }
+} else {
+  console.log('  - admin lifecycle skipped (SMOKE_ADMIN_TOKEN not set)')
+}
+
 if (failed > 0) {
   console.error(`\n${failed} smoke check(s) failed against ${base}`)
   process.exit(1)
 }
-console.log(`\nall ${checks.length} smoke checks passed against ${base}`)
+console.log(`\nall smoke checks passed against ${base}`)

--- a/src/app.ts
+++ b/src/app.ts
@@ -13,6 +13,7 @@ import {
   getConfiguredRefsWithEtag,
   latestVersionByPr,
   registerRef,
+  unregisterRef,
 } from './preview/getConfiguredRefs'
 import { parseConfiguredPreviewRefs } from './preview/parseConfiguredPreviewRefs'
 import {
@@ -323,13 +324,19 @@ app.get('/-/refs', async (c) => {
 
 /**
  * Purge a generated build from R2. Body:
- * `{ "package": "vite-plus", "version": "0.0.0-commit.<sha>" }`.
+ * `{ "package": "vite-plus", "version": "0.0.0-commit.<sha>", "unregister"?: boolean }`.
+ *
+ * `unregister: true` also removes the version's ref from the runtime index
+ * (e.g. to fully clean up a smoke-test artifact). It is opt-in because the ref
+ * is shared by every package published at that version: unregistering hides
+ * them all, while a plain purge only removes this one package's artifacts.
  */
 app.post('/-/purge', async (c) => {
   admin(c)
   const body = (await c.req.json().catch(() => ({}))) as {
     package?: string
     version?: string
+    unregister?: boolean
   }
   const name = body.package ?? ''
   const version = body.version ?? ''
@@ -337,7 +344,8 @@ app.post('/-/purge', async (c) => {
   if (!isWorkspacePackage(name, c.env)) {
     throw new HttpError(400, `Unknown preview package: ${name || '(empty)'}`)
   }
-  if (!parsePreviewVersion(version)) {
+  const parsed = parsePreviewVersion(version)
+  if (!parsed) {
     throw new HttpError(400, `Invalid preview version: ${version || '(empty)'}`)
   }
 
@@ -345,6 +353,9 @@ app.post('/-/purge', async (c) => {
     c.env.STORAGE.delete(tarballKey(name, version)),
     c.env.STORAGE.delete(metaKey(name, version)),
     removeFromMetaIndex(c.env, name, version),
+    ...(body.unregister === true
+      ? [unregisterRef(c.env, `${parsed.type}.${parsed.ref}`)]
+      : []),
   ])
   return c.json({ purged: { package: name, version } })
 })

--- a/src/preview/getConfiguredRefs.ts
+++ b/src/preview/getConfiguredRefs.ts
@@ -116,6 +116,18 @@ export function latestVersionByPr(
   return out
 }
 
+/**
+ * Remove a ref from the runtime index (used by purge with `unregister: true`,
+ * e.g. to fully clean up a smoke-test artifact). Concurrency-safe via the
+ * conditional put; removing an absent ref is a no-op.
+ */
+export async function unregisterRef(env: Env, ref: string): Promise<void> {
+  const [parsed] = parseConfiguredPreviewRefs(ref)
+  await mutateRefIndex(env, (index) => {
+    delete index[canonical(parsed)]
+  })
+}
+
 /** Validate and register a ref. Concurrency-safe via the conditional put. */
 export async function registerRef(
   env: Env,

--- a/test/worker.test.ts
+++ b/test/worker.test.ts
@@ -1002,6 +1002,33 @@ describe('admin: purge', () => {
     })
   })
 
+  it('unregister:true also removes the ref; default leaves it registered', async () => {
+    const listedRefs = async () =>
+      ((await (await SELF.fetch(`${BASE}/-/refs`)).json()) as any).refs.map(
+        (r: any) => r.ref,
+      )
+    const purge = (unregister?: boolean) =>
+      SELF.fetch(`${BASE}/-/purge`, {
+        method: 'POST',
+        headers: { ...AUTH, 'content-type': 'application/json' },
+        body: JSON.stringify({
+          package: 'vite-plus',
+          version: FIXTURE_VERSION,
+          ...(unregister === undefined ? {} : { unregister }),
+        }),
+      })
+
+    // Default purge: artifacts go, the ref stays registered (other packages of
+    // the same version keep being served).
+    expect((await purge()).status).toBe(200)
+    expect(await listedRefs()).toContain('commit.a832a55')
+
+    // unregister:true removes the ref too, so a fully-cleaned-up version (e.g.
+    // a smoke-test artifact) stops appearing in /-/refs and packuments.
+    expect((await purge(true)).status).toBe(200)
+    expect(await listedRefs()).not.toContain('commit.a832a55')
+  })
+
   it('drops the purged version from the meta aggregate', async () => {
     const sha = 'cdcdcd0'
     const ver = `0.0.0-commit.${sha}`


### PR DESCRIPTION
## Why
The publish → register → serve → integrity path has **no end-to-end coverage**. Both of today's production incidents (missing tar end-of-archive terminator; a served tarball whose bytes didn't match the packument's advertised integrity) passed every pool-workers unit test and only surfaced on the real Void runtime after deploy.

## What
`scripts/smoke-test.mjs` gains an admin write-lifecycle check, gated on `SMOKE_ADMIN_TOKEN`. Against the real deployed runtime it:

1. Uploads a real preview tarball (`PUT /-/tarball`), integrity derived from the exact bytes
2. Publishes its meta (`POST /-/publish`)
3. Asserts the version is **NOT** served yet (the atomic register gate from #53)
4. Registers the ref (`POST /-/register`)
5. Asserts the packument advertises an integrity that **matches the served tarball bytes** (the invariant both incidents broke)
6. Purges the artifact

Uses a unique `e2e<timestamp>` commit sha so it never collides with real refs.

## Where it runs
- `staging.yml` (every PR) and the deploy workflow's **staging** step get `SMOKE_ADMIN_TOKEN` → full write flow
- Production smoke never gets the token → stays read-only (no test artifacts on the live bridge)
- Fork PRs can't read the secret → the write flow skips (loud log line), read-only checks still run

## Verified
Ran end-to-end against a local `wrangler dev` with an admin token: all steps pass, atomic gate holds, integrity matches, purge cleans up. Skip-path verified against real staging (currently no token). 83/83 unit tests, typecheck clean.

## Activation required
The write flow is inert until `STAGING_ADMIN_TOKEN` exists. See the PR thread for the two setup commands (set `ADMIN_TOKEN` on the staging Void project + add the matching repo secret).