### PR TITLE
Deploy on push to main via GitHub OIDC instead of VOID_TOKEN

### DIFF
--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -34,6 +34,11 @@ jobs:
       # unit tests can't (e.g. the Void Cache API ban that 500'd every packument)
       # BEFORE the change reaches main. Make this a required status check so a
       # failing smoke test blocks the merge.
+      #
+      # This deploy keeps the long-lived VOID_TOKEN secret: the GitHub OIDC
+      # exchange that void-deploy.yml uses is rejected for pull_request events
+      # by the Void platform (PR runs execute untrusted code, so they may not
+      # mint deploy tokens), so OIDC cannot replace the token here.
       - name: Deploy to staging
         run: pnpm exec void deploy --project pkg-pr-registry-bridge-staging
         env:

--- a/.github/workflows/void-deploy.yml
+++ b/.github/workflows/void-deploy.yml
@@ -9,6 +9,15 @@ concurrency:
   group: void-deploy-${{ github.ref }}
   cancel-in-progress: true
 
+# `void deploy` authenticates via GitHub OIDC, so there is no long-lived
+# VOID_TOKEN secret here: id-token lets the job mint an OIDC token that the
+# CLI exchanges for a short-lived project-scoped deploy token. The Void
+# platform only honors the exchange from `.github/workflows/void-deploy.yml`
+# on a push to the connected branch, so this file must keep exactly that name.
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
@@ -33,8 +42,6 @@ jobs:
       # staging deploy + smoke here and only ship to production when it passes.
       - name: Deploy to staging
         run: pnpm exec void deploy --project pkg-pr-registry-bridge-staging
-        env:
-          VOID_TOKEN: ${{ secrets.VOID_TOKEN }}
 
       # --write runs the admin write lifecycle too (see scripts/smoke-test.mjs
       # header); staging only, production smoke below stays read-only.
@@ -47,9 +54,9 @@ jobs:
       - name: Deploy to production
         run: pnpm exec void deploy
         env:
-          VOID_TOKEN: ${{ secrets.VOID_TOKEN }}
           # VOID_PROJECT is required because the project link in `.void/` is
-          # gitignored, so there is nothing to resolve from in CI.
+          # gitignored, so there is nothing to resolve from in CI. The OIDC
+          # exchange also scopes the deploy token to this slug.
           VOID_PROJECT: pkg-pr-registry-bridge
 
       # No --write: read-only against the live bridge.

--- a/README.md
+++ b/README.md
@@ -279,14 +279,22 @@ CI deploys in two stages, both smoke-testing the REAL Void runtime, which the
   runs `scripts/smoke-test.mjs` against it. Make `Staging` a required status
   check (branch protection) so a failing smoke test blocks the merge. (Skipped
   for fork PRs, which can't read `VOID_TOKEN`.)
-- **Push to `main`** (`.github/workflows/deploy.yml`) re-runs the staging deploy
-  + smoke as a gate, then deploys to production and smoke-tests it. The gate is
-  necessary because a change can reach `main` without the PR check, a fork PR or
-  a direct push, so production never ships unless staging passes first.
+- **Push to `main`** (`.github/workflows/void-deploy.yml`) re-runs the staging
+  deploy + smoke as a gate, then deploys to production and smoke-tests it. The
+  gate is necessary because a change can reach `main` without the PR check, a
+  fork PR or a direct push, so production never ships unless staging passes
+  first.
 
 The smoke test hits `/_health`, the `/vite-plus` packument (200 with `time`),
 `/-/refs`, and a download redirect.
 
-Add a `VOID_TOKEN` repository secret (`void auth token` copies one to your
-clipboard); the same token deploys both projects. Run the smoke test locally
-with `pnpm smoke <url>`, and deploy staging by hand with `pnpm deploy:staging`.
+The push-to-`main` workflow authenticates with GitHub OIDC: `void deploy`
+exchanges a short-lived OIDC token for a project-scoped deploy token, so no
+secret is involved. This requires the repo to be connected once per project
+(`void github connect <project> --repo voidzero-dev/pkg-pr-registry-bridge
+--branch main --executor github_actions`) and the workflow file to be named
+exactly `void-deploy.yml`. The PR staging deploy still needs a `VOID_TOKEN`
+repository secret (`void auth token` copies one to your clipboard): the
+platform refuses to mint deploy tokens for pull_request events, which run
+untrusted code. Run the smoke test locally with `pnpm smoke <url>`, and deploy
+staging by hand with `pnpm deploy:staging`.

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "typescript": "^6.0.0",
     "vite": "^8.1.0",
     "vitest": "^4.1.0",
-    "void": "^0.9.3",
+    "void": "^0.10.5",
     "wrangler": "^4.105.0"
   },
   "devEngines": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -233,8 +233,8 @@ importers:
         specifier: ^4.1.0
         version: 4.1.9(@types/node@24.13.2)(vite@8.1.0(@types/node@24.13.2)(esbuild@0.28.1)(tsx@4.22.4))
       void:
-        specifier: ^0.9.3
-        version: 0.9.3(arktype@2.2.1)(kysely@0.29.2)(valibot@1.4.1(typescript@6.0.3))(vite@8.1.0(@types/node@24.13.2)(esbuild@0.28.1)(tsx@4.22.4))(vitest@4.1.9(@types/node@24.13.2)(vite@8.1.0(@types/node@24.13.2)(esbuild@0.28.1)(tsx@4.22.4)))(workerd@1.20260625.1)(zod@4.4.3)
+        specifier: ^0.10.5
+        version: 0.10.5(arktype@2.2.1)(kysely@0.29.2)(valibot@1.4.1(typescript@6.0.3))(vite@8.1.0(@types/node@24.13.2)(esbuild@0.28.1)(tsx@4.22.4))(vitest@4.1.9(@types/node@24.13.2)(vite@8.1.0(@types/node@24.13.2)(esbuild@0.28.1)(tsx@4.22.4)))(workerd@1.20260625.1)(zod@4.4.3)
       wrangler:
         specifier: ^4.105.0
         version: 4.105.0(@cloudflare/workers-types@4.20260626.1)
@@ -2064,11 +2064,11 @@ packages:
       jsdom:
         optional: true
 
-  void@0.9.3:
-    resolution: {integrity: sha512-qCQrUTAjp2bOSbr9JeIysghEkDcUWG7KszgCpQ9ZzHmbmbPkWlkyRpQ8hhVmvO62h/QXEK6N7CXHTpMfg8iNMA==}
+  void@0.10.5:
+    resolution: {integrity: sha512-tjvHCFe89YF0XNRuFtTv89gN7CRqxtkqmq/6E6IlreT6OkG89pd/diirhjyukyVBFiMCeyL7FBTSN0xhDfCQkw==}
     hasBin: true
     peerDependencies:
-      '@void/md': 0.9.3
+      '@void/md': 0.10.5
       arktype: '>=2.0.0'
       valibot: '>=1.0.0-beta.7'
       vite: ^8.0.0
@@ -3452,7 +3452,7 @@ snapshots:
     transitivePeerDependencies:
       - msw
 
-  void@0.9.3(arktype@2.2.1)(kysely@0.29.2)(valibot@1.4.1(typescript@6.0.3))(vite@8.1.0(@types/node@24.13.2)(esbuild@0.28.1)(tsx@4.22.4))(vitest@4.1.9(@types/node@24.13.2)(vite@8.1.0(@types/node@24.13.2)(esbuild@0.28.1)(tsx@4.22.4)))(workerd@1.20260625.1)(zod@4.4.3):
+  void@0.10.5(arktype@2.2.1)(kysely@0.29.2)(valibot@1.4.1(typescript@6.0.3))(vite@8.1.0(@types/node@24.13.2)(esbuild@0.28.1)(tsx@4.22.4))(vitest@4.1.9(@types/node@24.13.2)(vite@8.1.0(@types/node@24.13.2)(esbuild@0.28.1)(tsx@4.22.4)))(workerd@1.20260625.1)(zod@4.4.3):
     dependencies:
       '@cloudflare/sandbox': 0.10.3
       '@cloudflare/vite-plugin': 1.42.3(vite@8.1.0(@types/node@24.13.2)(esbuild@0.28.1)(tsx@4.22.4))(workerd@1.20260625.1)(wrangler@4.105.0(@cloudflare/workers-types@4.20260626.1))

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,3 +8,5 @@ allowBuilds:
   workerd: true
   sharp: true
   better-sqlite3: false
+minimumReleaseAgeExclude:
+  - void@0.10.5


### PR DESCRIPTION
Bumps void to 0.10.5 and switches the push-to-main deploy workflow to the new GitHub OIDC flow: `void deploy` exchanges a short-lived OIDC token for a project-scoped deploy token, so the workflow no longer reads the long-lived `VOID_TOKEN` secret.

- `deploy.yml` renamed to `void-deploy.yml` (the connection's authorized deploy workflow path) with `permissions: id-token: write`.
- `staging.yml` (PR deploys) keeps `VOID_TOKEN`: the platform rejects the OIDC exchange for pull_request events, since PR runs execute untrusted code.

Both projects are connected via the org-shared installation (`void github join` + `void github connect`, executor `github_actions`, branch `main`, workflow `void-deploy.yml`), so this is safe to merge; the first push to main will do the OIDC-authenticated staging -> smoke -> prod -> smoke run.