### PR TITLE
Fix ERR_PNPM_TARBALL_INTEGRITY with content-addressed tarball URLs

### DIFF
--- a/.github/actions/publish-preview/dist/index.mjs
+++ b/.github/actions/publish-preview/dist/index.mjs
@@ -628,9 +628,9 @@ async function withRetry(label, fn, attempts = 4) {
 }
 var TRANSFER_TIMEOUT_MS = 12e4;
 var PUBLISH_TIMEOUT_MS = 3e4;
-async function uploadTarball(bridge, token, name, version, bytes) {
+async function uploadTarball(bridge, token, name, version, bytes, shasum) {
   await withRetry(`upload ${name}`, async () => {
-    const res = await fetch(`${bridge}/-/tarball/${name}/${version}.tgz`, {
+    const res = await fetch(`${bridge}/-/tarball/${name}/${version}/${shasum}.tgz`, {
       method: "PUT",
       headers: { authorization: `Bearer ${token}`, "content-type": "application/gzip" },
       body: bytes,
@@ -680,7 +680,7 @@ async function main() {
     const packed = await nextPack;
     if (i + 1 < packages.length) nextPack = startPack(i + 1);
     const build = await buildPreviewTarball(packed, manifest.name, version, env, batch);
-    await uploadTarball(bridge, token, manifest.name, version, build.tarball);
+    await uploadTarball(bridge, token, manifest.name, version, build.tarball, build.shasum);
     const pkg = {
       name: manifest.name,
       version,

--- a/.github/actions/publish-preview/src/index.ts
+++ b/.github/actions/publish-preview/src/index.ts
@@ -71,9 +71,13 @@ async function uploadTarball(
   name: string,
   version: string,
   bytes: Uint8Array,
+  shasum: string,
 ): Promise<void> {
   await withRetry(`upload ${name}`, async () => {
-    const res = await fetch(`${bridge}/-/tarball/${name}/${version}.tgz`, {
+    // Content-addressed path: the shasum (sha1 of these exact bytes) is in the
+    // key, so a republish with different bytes lands at a different URL and the
+    // packument's shasum always selects the matching bytes.
+    const res = await fetch(`${bridge}/-/tarball/${name}/${version}/${shasum}.tgz`, {
       method: 'PUT',
       headers: { authorization: `Bearer ${token}`, 'content-type': 'application/gzip' },
       body: bytes,
@@ -149,7 +153,7 @@ async function main(): Promise<void> {
     const packed = await nextPack
     if (i + 1 < packages.length) nextPack = startPack(i + 1)
     const build = await buildPreviewTarball(packed, manifest.name, version, env, batch)
-    await uploadTarball(bridge, token, manifest.name, version, build.tarball)
+    await uploadTarball(bridge, token, manifest.name, version, build.tarball, build.shasum)
     const pkg = {
       name: manifest.name,
       version,

--- a/scripts/smoke-test.mjs
+++ b/scripts/smoke-test.mjs
@@ -80,6 +80,8 @@ async function runAdminLifecycle() {
     { name: 'package/index.js', data: 'export const smoke = true\n' },
   ])
   const integrity = sri(tarball)
+  // sha1 hex, the content id in the content-addressed tarball URL/key.
+  const shasum = createHash('sha1').update(tarball).digest('hex')
 
   const fetchDist = async () => {
     const res = await fetch(`${base}/${name}`, {
@@ -90,8 +92,9 @@ async function runAdminLifecycle() {
   }
 
   try {
-    // 1. Upload the tarball bytes (worker streams them straight into R2).
-    const up = await fetch(`${base}/-/tarball/${name}/${version}.tgz`, {
+    // 1. Upload the tarball bytes to the content-addressed path (shasum in the
+    // key); the worker streams them straight into R2.
+    const up = await fetch(`${base}/-/tarball/${name}/${version}/${shasum}.tgz`, {
       method: 'PUT',
       headers: { authorization: `Bearer ${ADMIN_TOKEN}`, 'content-type': 'application/gzip' },
       body: tarball,
@@ -100,7 +103,6 @@ async function runAdminLifecycle() {
     assert(up.status === 201, `upload status ${up.status}`)
 
     // 2. Publish the meta. This must NOT make the version visible on its own.
-    const shasum = createHash('sha1').update(tarball).digest('hex')
     const pub = await postJson('/-/publish', {
       ref,
       packages: [{ name, version, packageJson: { name, version }, integrity, shasum }],
@@ -121,9 +123,15 @@ async function runAdminLifecycle() {
     // 5. Now it is served, and its advertised integrity must match the bytes
     // (the invariant both production incidents violated).
     const dist = await fetchDist()
-    console.log(`    packument after register: integrity=${dist?.integrity?.slice(0, 20)}…`)
+    console.log(`    packument after register: integrity=${dist?.integrity?.slice(0, 20)}… tarball=${dist?.tarball}`)
     assert(dist, 'version absent from packument after register')
     assert(dist.integrity === integrity, 'packument integrity != uploaded integrity')
+    // dist.tarball is the content-addressed URL: the shasum lives in the path,
+    // so the URL pins the exact build the integrity was computed from.
+    assert(
+      dist.tarball && dist.tarball.endsWith(`/tarballs/${name}/${version}/${shasum}.tgz`),
+      `dist.tarball is not the content URL: ${dist.tarball}`,
+    )
 
     // 6. Fetch the actually-served tarball from the runtime under test and
     // confirm its bytes hash to the advertised integrity (catches a stale or

--- a/src/app.ts
+++ b/src/app.ts
@@ -377,20 +377,24 @@ app.post('/-/purge', async (c) => {
   }
 
   // Every content-addressed build of the version lives under casVersionPrefix
-  // (one object per shasum). List and delete them all, so NO
-  // /tarballs/.../<shasum>.tgz stays installable after a purge — not just the
-  // current build's. Resolving a single meta shasum would leave every earlier
-  // republish's CAS object serving until the age sweep. One list page suffices
-  // (a version won't exceed 1000 builds).
-  const casObjects = (
-    await c.env.STORAGE.list({ prefix: casVersionPrefix(name, version) })
-  ).objects
+  // (one object per shasum). Delete them all, so NO /tarballs/.../<shasum>.tgz
+  // stays installable after a purge, not just the current build's. Page through
+  // the listing (a heavily re-run commit can exceed one 1000-key list page, and
+  // R2 bulk delete also caps at 1000 keys), deleting each page as we go.
+  let cursor: string | undefined
+  do {
+    const listing = await c.env.STORAGE.list({
+      prefix: casVersionPrefix(name, version),
+      cursor,
+    })
+    if (listing.objects.length > 0) {
+      await c.env.STORAGE.delete(listing.objects.map((o) => o.key))
+    }
+    cursor = listing.truncated ? listing.cursor : undefined
+  } while (cursor)
   await Promise.all([
     c.env.STORAGE.delete(tarballKey(name, version)),
     c.env.STORAGE.delete(metaKey(name, version)),
-    ...(casObjects.length
-      ? [c.env.STORAGE.delete(casObjects.map((o) => o.key))]
-      : []),
     removeFromMetaIndex(c.env, name, version),
     ...(body.unregister === true
       ? [unregisterRef(c.env, `${parsed.type}.${parsed.ref}`)]

--- a/src/app.ts
+++ b/src/app.ts
@@ -19,6 +19,7 @@ import { parseConfiguredPreviewRefs } from './preview/parseConfiguredPreviewRefs
 import {
   readMetaIndex,
   removeFromMetaIndex,
+  resolveVersionMeta,
   upsertMetaIndex,
 } from './preview/metaIndex'
 import {
@@ -39,7 +40,15 @@ import {
   getPreviewTarballBody,
 } from './tarball/getPreviewBuild'
 import type { PreviewMeta } from './tarball/buildPreviewTarball'
-import { metaKey, tarballKey, tarballUrl } from './cache/r2Cache'
+import {
+  casKey,
+  casVersionPrefix,
+  isShasum,
+  metaKey,
+  tarballContentUrl,
+  tarballKey,
+  tarballUrl,
+} from './cache/r2Cache'
 import { kvCachedText } from './cache/kvCache'
 import { requireAdmin } from './security/auth'
 import {
@@ -114,19 +123,23 @@ async function serveTarball(
   env: Env,
   name: string,
   version: string,
+  shasum?: string,
 ): Promise<Response> {
   assertPreviewTarget(env, name, version)
-  const result = await getPreviewTarballBody(env, name, version)
+  const result = await getPreviewTarballBody(env, name, version, shasum)
   if (result.kind === 'redirect') {
     return new Response(null, {
       status: 302,
       headers: { location: result.location, 'cache-control': 'no-store' },
     })
   }
+  // Content-addressed bytes are immutable (the URL pins them); a version-
+  // addressed body (no shasum published yet) is only short-lived cacheable
+  // because the version->build mapping can still change.
   return new Response(result.body, {
     headers: {
       'content-type': 'application/gzip',
-      'cache-control': tarballCacheControl(),
+      'cache-control': result.immutable ? tarballCacheControl() : packumentCacheControl(),
       'content-length': String(result.contentLength),
     },
   })
@@ -167,9 +180,17 @@ async function serveDownloadRedirect(
       headers: { ...headers, 'content-type': 'application/tar+gzip' },
     })
   }
+  // Point at the version's CURRENT build's content URL when a shasum is
+  // published (so the download resolves the exact advertised bytes), else the
+  // version URL (nothing published yet, or a meta without a shasum).
+  const meta = await resolveVersionMeta(env, download.pkg, version)
+  const location =
+    meta && isShasum(meta.shasum)
+      ? tarballContentUrl(env, download.pkg, version, meta.shasum)
+      : tarballUrl(env, download.pkg, version)
   return new Response(null, {
     status: 302,
-    headers: { ...headers, location: tarballUrl(env, download.pkg, version) },
+    headers: { ...headers, location },
   })
 }
 
@@ -179,7 +200,7 @@ app.get('/tarballs/*', async (c) => {
   if (!parsed) throw new HttpError(404, 'Not found')
   // `await` so a thrown HttpError unwinds inside this handler's frame and is
   // routed to onError, rather than rejecting the returned promise unhandled.
-  return await serveTarball(c.env, parsed.name, parsed.version)
+  return await serveTarball(c.env, parsed.name, parsed.version, parsed.shasum)
 })
 
 /**
@@ -192,16 +213,22 @@ app.put('/-/tarball/*', async (c) => {
   admin(c)
   const parsed = parseUploadPath(new URL(c.req.url).pathname)
   if (!parsed) throw new HttpError(404, 'Not found')
-  const { name, version } = parsed
+  const { name, version, shasum } = parsed
   assertPreviewTarget(c.env, name, version)
   if (!c.req.raw.body) throw new HttpError(400, 'Missing request body')
-  await c.env.STORAGE.put(tarballKey(name, version), c.req.raw.body, {
+  // Store content-addressed (keyed by the shasum in the path) when the upload
+  // is a content path; else fall back to the legacy version-addressed key.
+  const key = isShasum(shasum) ? casKey(name, version, shasum) : tarballKey(name, version)
+  await c.env.STORAGE.put(key, c.req.raw.body, {
     httpMetadata: {
       contentType: 'application/gzip',
       cacheControl: tarballCacheControl(),
     },
   })
-  return c.json({ uploaded: { package: name, version } }, 201)
+  return c.json(
+    { uploaded: { package: name, version, ...(isShasum(shasum) ? { shasum } : {}) } },
+    201,
+  )
 })
 
 /**
@@ -349,9 +376,21 @@ app.post('/-/purge', async (c) => {
     throw new HttpError(400, `Invalid preview version: ${version || '(empty)'}`)
   }
 
+  // Every content-addressed build of the version lives under casVersionPrefix
+  // (one object per shasum). List and delete them all, so NO
+  // /tarballs/.../<shasum>.tgz stays installable after a purge — not just the
+  // current build's. Resolving a single meta shasum would leave every earlier
+  // republish's CAS object serving until the age sweep. One list page suffices
+  // (a version won't exceed 1000 builds).
+  const casObjects = (
+    await c.env.STORAGE.list({ prefix: casVersionPrefix(name, version) })
+  ).objects
   await Promise.all([
     c.env.STORAGE.delete(tarballKey(name, version)),
     c.env.STORAGE.delete(metaKey(name, version)),
+    ...(casObjects.length
+      ? [c.env.STORAGE.delete(casObjects.map((o) => o.key))]
+      : []),
     removeFromMetaIndex(c.env, name, version),
     ...(body.unregister === true
       ? [unregisterRef(c.env, `${parsed.type}.${parsed.ref}`)]

--- a/src/cache/r2Cache.ts
+++ b/src/cache/r2Cache.ts
@@ -5,9 +5,36 @@ import type { Env } from '../config'
 // (cleanupExpiredArtifacts), so a rename here can't silently desync it.
 export const TARBALL_PREFIX = 'tarball/'
 export const META_PREFIX = 'meta/'
+// Content-addressed bytes prefix (bytes keyed by their own sha1, see casKey).
+export const CAS_PREFIX = 'cas/'
 
 export function tarballKey(name: string, version: string): string {
   return `${TARBALL_PREFIX}${name}/${version}.tgz`
+}
+
+/**
+ * Content-addressed tarball key: bytes keyed by their own sha1 (dist.shasum),
+ * so two distinct builds of a version never overwrite each other. A republish
+ * with different bytes lands at a different key and both coexist. The version
+ * sits in the key (mirroring the content URL) so every build of a version is
+ * listable under one prefix, which is what `/-/purge` enumerates.
+ */
+export function casKey(name: string, version: string, shasum: string): string {
+  return `${CAS_PREFIX}${name}/${version}/${shasum}.tgz`
+}
+
+/**
+ * The prefix covering EVERY content-addressed build of a version, so `/-/purge`
+ * can list and delete them all (not just the current shasum). Mirrors the
+ * `casKey` layout with the trailing `<shasum>.tgz` dropped.
+ */
+export function casVersionPrefix(name: string, version: string): string {
+  return `${CAS_PREFIX}${name}/${version}/`
+}
+
+/** A valid dist.shasum (sha1 hex) — the content id in a content-addressed URL/key. */
+export function isShasum(s: string | undefined): s is string {
+  return !!s && /^[0-9a-f]{40}$/.test(s)
 }
 
 /** Public URL of a preview tarball (the inverse of parseTarballPath). */
@@ -17,6 +44,20 @@ export function tarballUrl(
   version: string,
 ): string {
   return `${env.PUBLIC_BASE_URL}/tarballs/${name}/${version}.tgz`
+}
+
+/**
+ * Content-addressed public URL. A re-published build has a different shasum ->
+ * a different URL, so a client fetches the exact build its packument advertised
+ * and `immutable` caching is always correct.
+ */
+export function tarballContentUrl(
+  env: Pick<Env, 'PUBLIC_BASE_URL'>,
+  name: string,
+  version: string,
+  shasum: string,
+): string {
+  return `${env.PUBLIC_BASE_URL}/tarballs/${name}/${version}/${shasum}.tgz`
 }
 
 export function metaKey(name: string, version: string): string {

--- a/src/preview/cleanupExpired.ts
+++ b/src/preview/cleanupExpired.ts
@@ -1,23 +1,27 @@
 import type { Env } from '../config'
-import { META_PREFIX, TARBALL_PREFIX } from '../cache/r2Cache'
+import { CAS_PREFIX, META_PREFIX, TARBALL_PREFIX } from '../cache/r2Cache'
 import { REF_TTL_MS } from './getConfiguredRefs'
 
-// The per-version artifact prefixes (shared with the key builders). NOT
-// `meta-index/` or `refs/`: those are the live indexes (self-pruned on write),
-// not per-version orphans, and their prefixes are disjoint from these.
-const ARTIFACT_PREFIXES = [META_PREFIX, TARBALL_PREFIX]
+// The per-version/per-content artifact prefixes (shared with the key builders).
+// NOT `meta-index/` or `refs/`: those are the live indexes (self-pruned on
+// write), not per-version orphans, and their prefixes are disjoint from these.
+const ARTIFACT_PREFIXES = [META_PREFIX, TARBALL_PREFIX, CAS_PREFIX]
 
 /**
- * Delete per-version preview artifacts (meta + tarball) whose ref TTL has lapsed,
- * so R2 storage stays bounded to the active-ref window rather than growing with
- * every ref ever published.
+ * Delete per-version preview artifacts (meta + tarball) and content-addressed
+ * bytes (cas) whose ref TTL has lapsed, so R2 storage stays bounded to the
+ * active-ref window rather than growing with every ref (or every republish)
+ * ever seen.
  *
- * A ref's objects are (re-)uploaded on each publish, so an object's `uploaded`
- * age equals its ref's age, and the ref TTL maps exactly to
+ * A still-referenced ref (re-)uploads its objects on each publish, so an
+ * object's `uploaded` age equals its ref's age, and the ref TTL maps exactly to
  * `uploaded < now - REF_TTL_MS`. An active ref (published within the window) is
  * therefore never touched; an expired ref's objects, which are no longer served
- * (the packument skips expired refs), are the orphans this removes. `now` is
- * injectable for tests.
+ * (the packument skips expired refs), are the orphans this removes. A cas object
+ * is swept the same way: a rerun uploads a NEW cas object and re-publishes the
+ * meta (both refreshed), so a still-referenced build's cas is always freshly
+ * uploaded and ages with its ref, while a superseded build's cas (no longer
+ * advertised) ages out. `now` is injectable for tests.
  */
 export async function cleanupExpiredArtifacts(
   env: Pick<Env, 'STORAGE'>,

--- a/src/preview/metaIndex.ts
+++ b/src/preview/metaIndex.ts
@@ -1,6 +1,6 @@
 import type { Env } from '../config'
 import type { PreviewMeta } from '../tarball/buildPreviewTarball'
-import { metaIndexKey } from '../cache/r2Cache'
+import { metaIndexKey, metaKey } from '../cache/r2Cache'
 import { casR2Json, readR2Json } from '../cache/r2Cas'
 import { REF_TTL_MS } from './getConfiguredRefs'
 
@@ -14,6 +14,25 @@ export type MetaIndex = Record<string, PreviewMeta>
  */
 export async function readMetaIndex(env: Env, name: string): Promise<MetaIndex> {
   return (await readR2Json<MetaIndex>(env, metaIndexKey(name))).value
+}
+
+/**
+ * Resolve a version's current meta WITHOUT triggering an in-Worker build: the
+ * per-package aggregate first (one R2 get), then the per-version `metaKey`
+ * fallback. Used by the serve + download-redirect paths to map a version to its
+ * current build's shasum (and thus its content-addressed URL). Returns undefined
+ * when nothing is published yet, so the caller falls back to the version URL.
+ */
+export async function resolveVersionMeta(
+  env: Env,
+  name: string,
+  version: string,
+): Promise<PreviewMeta | undefined> {
+  const fromIndex = (await readMetaIndex(env, name))[version]
+  if (fromIndex) return fromIndex
+  const obj = await env.STORAGE.get(metaKey(name, version))
+  if (!obj) return undefined
+  return obj.json<PreviewMeta>().catch(() => undefined)
 }
 
 /**

--- a/src/registry/buildVersionMetadata.ts
+++ b/src/registry/buildVersionMetadata.ts
@@ -1,6 +1,6 @@
 import type { Env } from '../config'
 import type { PreviewMeta } from '../tarball/buildPreviewTarball'
-import { tarballUrl } from '../cache/r2Cache'
+import { isShasum, tarballContentUrl, tarballUrl } from '../cache/r2Cache'
 
 /**
  * Fields from a package.json that should not appear in a registry version
@@ -48,8 +48,18 @@ export function buildVersionMetadata(
   meta.version = version
   meta._id = `${packageName}@${version}`
 
+  // Point `dist.tarball` at the content-addressed URL (shasum in the path) when
+  // a shasum is known, so a client always fetches the exact build this meta
+  // advertises. Platform binaries without a published shasum yet fall back to
+  // the version URL (which the bridge redirects to the current build).
   const dist: Record<string, any> = {
-    tarball: tarballUrl(env, packageName, version),
+    // Only a valid sha1 hex builds a content URL: `parseTarballPath` recognises
+    // the trailing segment as a shasum only when it is 40-hex, so a malformed
+    // shasum must fall back to the version URL rather than emit an unparseable
+    // (404ing) content URL.
+    tarball: isShasum(preview.shasum)
+      ? tarballContentUrl(env, packageName, version, preview.shasum)
+      : tarballUrl(env, packageName, version),
   }
   if (preview.shasum) dist.shasum = preview.shasum
   if (preview.integrity) dist.integrity = preview.integrity

--- a/src/registry/parsePackageName.ts
+++ b/src/registry/parsePackageName.ts
@@ -8,6 +8,8 @@
  *   /@voidzero-dev%2Fvite-plus-core   (encoded scoped)
  */
 
+import { isShasum } from '../cache/r2Cache'
+
 export interface PackumentRequest {
   name: string
 }
@@ -49,9 +51,17 @@ export function parsePackagePath(pathname: string): PackumentRequest | null {
 export interface TarballRequest {
   name: string
   version: string
+  /** Present for a content-addressed path (`<name>/<version>/<shasum>.tgz`). */
+  shasum?: string
 }
 
-/** Parse a `<prefix><name>/<version>.tgz` path (name may be scoped). */
+/**
+ * Parse a `<prefix><name>/<version>.tgz` (version-addressed) or
+ * `<prefix><name>/<version>/<shasum>.tgz` (content-addressed) path; the name
+ * may be scoped. The two shapes are told apart by the basename: a content-
+ * addressed build's basename is a 40-hex shasum, which a `0.0.0-commit.<sha>`
+ * version can never be, so there is no ambiguity.
+ */
 function parsePrefixedTarballPath(
   pathname: string,
   prefix: string,
@@ -62,8 +72,21 @@ function parsePrefixedTarballPath(
   const segments = decoded.slice(prefix.length).split('/')
   const file = segments.pop()
   if (!file || !file.endsWith('.tgz')) return null
+  const base = file.slice(0, -'.tgz'.length)
 
-  const version = file.slice(0, -'.tgz'.length)
+  // Content-addressed `<name>/<version>/<shasum>.tgz`: the basename is a 40-hex
+  // shasum (a `0.0.0-commit.<sha>` version never is), and the prior segment is
+  // the version. `isShasum` is the shared content-vs-version disambiguator, so
+  // the parser and `buildVersionMetadata`'s gate stay in lockstep.
+  if (isShasum(base)) {
+    const version = segments.pop()
+    const name = segments.join('/')
+    if (!name || !version) return null
+    return { name, version, shasum: base }
+  }
+
+  // Legacy version-addressed `<name>/<version>.tgz`.
+  const version = base
   const name = segments.join('/')
   if (!name || !version) return null
   return { name, version }
@@ -71,7 +94,8 @@ function parsePrefixedTarballPath(
 
 /**
  * Parse the bridge's own preview tarball path:
- *   /tarballs/vite-plus/0.0.0-commit.a832a55.tgz
+ *   /tarballs/vite-plus/0.0.0-commit.a832a55.tgz                    (version)
+ *   /tarballs/vite-plus/0.0.0-commit.a832a55/<shasum>.tgz          (content)
  *   /tarballs/@voidzero-dev/vite-plus-core/0.0.0-commit.a832a55.tgz
  */
 export function parseTarballPath(pathname: string): TarballRequest | null {
@@ -80,7 +104,7 @@ export function parseTarballPath(pathname: string): TarballRequest | null {
 
 /**
  * Parse the admin artifact-upload path (CI uploads a prebuilt tarball here):
- *   /-/tarball/vite-plus/0.0.0-commit.a832a55.tgz
+ *   /-/tarball/vite-plus/0.0.0-commit.a832a55/<shasum>.tgz         (content)
  *   /-/tarball/@voidzero-dev/vite-plus-core/0.0.0-commit.a832a55.tgz
  */
 export function parseUploadPath(pathname: string): TarballRequest | null {

--- a/src/tarball/getPreviewBuild.ts
+++ b/src/tarball/getPreviewBuild.ts
@@ -4,8 +4,14 @@ import { HttpError } from '../httpError'
 import { isPreviewPackage } from '../preview/packages'
 import { platformInfoFromName } from '../preview/platformInfo'
 import { toPkgPrNewUrl } from '../preview/toPkgPrNewUrl'
-import { metaKey, tarballKey } from '../cache/r2Cache'
-import { upsertMetaIndex } from '../preview/metaIndex'
+import {
+  casKey,
+  isShasum,
+  metaKey,
+  tarballContentUrl,
+  tarballKey,
+} from '../cache/r2Cache'
+import { resolveVersionMeta, upsertMetaIndex } from '../preview/metaIndex'
 import { tarballCacheControl } from '../cache/headers'
 import {
   buildPreviewTarball,
@@ -44,13 +50,14 @@ async function buildAndStore(
     integrity: build.integrity,
     publishedAt,
   }
-  // Write the tarball and BOTH meta sources together. The rebuild replaces any
-  // previously published bytes (a workerd gzip stream differs byte-for-byte
-  // from CI's Node gzip of the same tar), so a stale meta-index entry would
-  // otherwise advertise an integrity the served tarball can no longer match,
-  // and the packument would flap between the two sources.
+  // Store the bytes CONTENT-ADDRESSED (keyed by this build's own shasum), so
+  // the content URL the packument advertises for this build resolves to exactly
+  // these bytes. A later rebuild has a different shasum -> a different cas key,
+  // so the two builds' bytes coexist instead of overwriting; the meta + index
+  // (last-write-wins below) just select which build the version currently
+  // advertises.
   await Promise.all([
-    env.STORAGE.put(tarballKey(name, version), build.tarball, {
+    env.STORAGE.put(casKey(name, version, build.shasum), build.tarball, {
       httpMetadata: { contentType: 'application/gzip', cacheControl },
     }),
     env.STORAGE.put(metaKey(name, version), JSON.stringify(meta), {
@@ -115,28 +122,73 @@ export async function getPreviewMeta(
 }
 
 /**
- * The generated tarball bytes for a preview version. Served from R2 when
- * present (a passthrough with a Content-Length that cannot be truncated). On a
- * miss: small preview packages are built in-Worker; platform binaries (never
- * built in-Worker) redirect to pkg.pr.new as a best-effort fallback for a ref
- * not yet published by CI. That fallback serves the original upstream bytes
- * (version 0.2.x), which npm/yarn/bun accept but pnpm's strict store check
- * rejects, so the published R2 path (where CI uploads a version-matched rewrite)
- * is the supported one; the redirect just avoids a hard 404 in the gap.
+ * The generated tarball bytes for a preview version. A content-addressed
+ * request (shasum in the path) serves those exact bytes and is `immutable`
+ * (the URL pins the content). A version-addressed request (old lockfile or the
+ * npm-convention path) resolves the version's CURRENT build and redirects to
+ * its content URL (the version->build mapping is mutable, so the caller marks
+ * that redirect no-store).
+ *
+ * Served from R2 when present (a passthrough with a Content-Length that cannot
+ * be truncated). On a miss: small preview packages are built in-Worker; platform
+ * binaries (never built in-Worker) redirect to pkg.pr.new as a best-effort
+ * fallback for a ref not yet published by CI. That fallback serves the original
+ * upstream bytes (version 0.2.x), which npm/yarn/bun accept but pnpm's strict
+ * store check rejects, so the published R2 path (where CI uploads a version-
+ * matched rewrite) is the supported one; the redirect just avoids a hard 404 in
+ * the gap.
  */
 export type PreviewTarball =
-  | { kind: 'body'; body: ReadableStream<Uint8Array> | Uint8Array; contentLength: number }
+  | {
+      kind: 'body'
+      body: ReadableStream<Uint8Array> | Uint8Array
+      contentLength: number
+      immutable: boolean
+    }
   | { kind: 'redirect'; location: string }
 
 export async function getPreviewTarballBody(
   env: Env,
   name: string,
   version: string,
+  shasum?: string,
 ): Promise<PreviewTarball> {
-  const cached = await env.STORAGE.get(tarballKey(name, version))
-  if (cached) {
-    return { kind: 'body', body: cached.body, contentLength: cached.size }
+  if (isShasum(shasum)) {
+    // Content-addressed request: a new-action publish always has the CAS object,
+    // so this is the hot path (one get) and its bytes are immutable (the URL
+    // pins the exact shasum).
+    const cas = await env.STORAGE.get(casKey(name, version, shasum))
+    if (cas) return { kind: 'body', body: cas.body, contentLength: cas.size, immutable: true }
+    // Migration fallback for an old version-addressed publish action: it stored
+    // the bytes at tarballKey and published this same shasum, so serve them for
+    // the CURRENT build's content URL. Gate on (meta.shasum === shasum) so a
+    // request for a SUPERSEDED shasum (the meta has moved on) 404s instead of
+    // getting stale bytes, and mark it NOT immutable: tarballKey is a mutable key,
+    // so a revalidatable response self-heals and can't poison a cache for a year.
+    // This runs only on a CAS miss (the old-action transition window or a
+    // genuinely absent build); it never serves a different build's bytes as
+    // immutable. The version republishes through the content path to restore the
+    // CAS object and return to the hot path.
+    const meta = await resolveVersionMeta(env, name, version)
+    if (meta && meta.shasum === shasum) {
+      const legacy = await env.STORAGE.get(tarballKey(name, version))
+      if (legacy) return { kind: 'body', body: legacy.body, contentLength: legacy.size, immutable: false }
+    }
+    throw new HttpError(404, `No such tarball: ${name}@${version} (${shasum})`)
   }
+
+  // Version-addressed request (old lockfile / npm-convention path): point at the
+  // canonical content URL for the version's CURRENT build. The mapping is
+  // mutable, so serveTarball marks the redirect no-store.
+  const meta = await resolveVersionMeta(env, name, version)
+  if (meta && isShasum(meta.shasum)) {
+    return { kind: 'redirect', location: tarballContentUrl(env, name, version, meta.shasum) }
+  }
+
+  // No published shasum yet: serve legacy version-addressed bytes if present,
+  // else (platform) redirect upstream, else build the small preview in-Worker.
+  const legacy = await env.STORAGE.get(tarballKey(name, version))
+  if (legacy) return { kind: 'body', body: legacy.body, contentLength: legacy.size, immutable: false }
 
   if (!isPreviewPackage(name)) {
     const url = toPkgPrNewUrl(env, name, version)
@@ -144,6 +196,6 @@ export async function getPreviewTarballBody(
     return { kind: 'redirect', location: url }
   }
 
-  const tarball = (await buildAndStore(env, name, version)).tarball
-  return { kind: 'body', body: tarball, contentLength: tarball.byteLength }
+  const build = await buildAndStore(env, name, version)
+  return { kind: 'body', body: build.tarball, contentLength: build.tarball.byteLength, immutable: false }
 }

--- a/test/republish-integrity.test.ts
+++ b/test/republish-integrity.test.ts
@@ -1,0 +1,244 @@
+import { SELF, env } from 'cloudflare:test'
+import {
+  casKey,
+  metaIndexKey,
+  metaKey,
+  tarballKey,
+} from '../src/cache/r2Cache'
+import { computeDigests } from '../src/tarball/digests'
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
+import { createTarGzip } from 'nanotar'
+
+// Content-addressed tarball URLs: the dist.shasum lives in the URL/key, so a
+// republish with different bytes gets a different URL and BOTH builds' bytes
+// coexist. This lets /-/publish stay last-write-wins with no write-once and no
+// revalidation, while the packument-advertised URL still always serves bytes
+// that hash to the advertised integrity — the invariant these tests pin down.
+
+const BASE = 'https://bridge.example.com'
+const AUTH = { authorization: 'Bearer test-admin-token' }
+const JSON_AUTH = { ...AUTH, 'content-type': 'application/json' }
+const NAME = 'vite-plus'
+
+// The worker-under-test (reached via SELF.fetch) runs in this isolate, so a
+// `vi.stubGlobal('fetch', ...)` mock intercepts its outbound npm/pkg.pr.new
+// calls; a 404 makes the packument synthesize a preview-only document, so these
+// tests do not depend on npm.
+beforeAll(() => {
+  vi.stubGlobal('fetch', (input: RequestInfo | URL) => {
+    const url = typeof input === 'string' ? input : input.toString()
+    if (url.startsWith('https://registry.npmjs.org/')) {
+      return Promise.resolve(
+        new Response(JSON.stringify({ error: 'Not found' }), {
+          status: 404,
+          headers: { 'content-type': 'application/json' },
+        }),
+      )
+    }
+    return Promise.reject(new Error(`unexpected fetch: ${url}`))
+  })
+})
+
+afterAll(() => vi.unstubAllGlobals())
+
+// A gzipped preview tarball whose `index.js` carries a marker, so two builds of
+// the same (name, version) can be given DISTINCT bytes (and thus distinct
+// shasums), mirroring a non-byte-reproducible rebuild.
+function makeTarball(
+  pkg: Record<string, any>,
+  marker: string,
+): Promise<Uint8Array> {
+  return createTarGzip([
+    { name: 'package/package.json', data: JSON.stringify(pkg) },
+    { name: 'package/index.js', data: `export const build = ${JSON.stringify(marker)}\n` },
+  ])
+}
+
+/** Upload bytes to the content-addressed path; returns their digests. */
+async function upload(
+  name: string,
+  version: string,
+  bytes: Uint8Array,
+): Promise<{ shasum: string; integrity: string }> {
+  const digests = await computeDigests(bytes)
+  const up = await SELF.fetch(`${BASE}/-/tarball/${name}/${version}/${digests.shasum}.tgz`, {
+    method: 'PUT',
+    headers: AUTH,
+    body: bytes,
+  })
+  expect(up.status).toBe(201)
+  return digests
+}
+
+/** Publish a package's meta and register the ref (the CI publish shape). */
+async function publishRegister(
+  name: string,
+  version: string,
+  ref: string,
+  packageJson: Record<string, any>,
+  digests: { shasum: string; integrity: string },
+): Promise<void> {
+  const pub = await SELF.fetch(`${BASE}/-/publish`, {
+    method: 'POST',
+    headers: JSON_AUTH,
+    body: JSON.stringify({
+      ref,
+      packages: [{ name, version, packageJson, integrity: digests.integrity, shasum: digests.shasum }],
+    }),
+  })
+  expect(pub.status).toBe(201)
+  const reg = await SELF.fetch(`${BASE}/-/register`, {
+    method: 'POST',
+    headers: JSON_AUTH,
+    body: JSON.stringify({ ref }),
+  })
+  expect(reg.status).toBe(201)
+}
+
+/** Upload bytes content-addressed, then publish + register (a full CI publish). */
+async function publishFull(
+  name: string,
+  version: string,
+  ref: string,
+  packageJson: Record<string, any>,
+  bytes: Uint8Array,
+): Promise<{ shasum: string; integrity: string }> {
+  const digests = await upload(name, version, bytes)
+  await publishRegister(name, version, ref, packageJson, digests)
+  return digests
+}
+
+/** Read the injected version's dist from the packument. */
+async function distFor(version: string): Promise<Record<string, any>> {
+  const res = await SELF.fetch(`${BASE}/${NAME}`, {
+    headers: { accept: 'application/vnd.npm.install-v1+json' },
+  })
+  expect(res.status).toBe(200)
+  const body = (await res.json()) as Record<string, any>
+  return body.versions[version].dist
+}
+
+/** Drop every artifact a case created, so nothing leaks across cases. */
+async function cleanup(version: string, shasums: string[]): Promise<void> {
+  await env.STORAGE.delete(metaKey(NAME, version))
+  await env.STORAGE.delete(metaIndexKey(NAME))
+  await env.STORAGE.delete(tarballKey(NAME, version))
+  for (const shasum of shasums) await env.STORAGE.delete(casKey(NAME, version, shasum))
+}
+
+describe('content-addressed republish integrity', () => {
+  it('republish with different bytes: both content URLs serve their own bytes; the packument advertises the last write', async () => {
+    const sha = 'ca50001'
+    const ref = `commit.${sha}`
+    const version = `0.0.0-commit.${sha}`
+    const pkg = { name: NAME, version }
+
+    const bytesA = await makeTarball(pkg, 'A')
+    const bytesB = await makeTarball(pkg, 'B')
+    const A = await computeDigests(bytesA)
+    const B = await computeDigests(bytesB)
+    // A non-byte-reproducible rebuild yields distinct content ids.
+    expect(A.shasum).not.toBe(B.shasum)
+
+    // Build A, then republish the SAME version with build B's bytes.
+    await publishFull(NAME, version, ref, pkg, bytesA)
+    await publishFull(NAME, version, ref, pkg, bytesB)
+
+    // Both content URLs coexist and each serves its OWN bytes (the losing run's
+    // bytes are not overwritten).
+    const resA = await SELF.fetch(`${BASE}/tarballs/${NAME}/${version}/${A.shasum}.tgz`)
+    expect(resA.status).toBe(200)
+    expect((await computeDigests(new Uint8Array(await resA.arrayBuffer()))).shasum).toBe(A.shasum)
+
+    const resB = await SELF.fetch(`${BASE}/tarballs/${NAME}/${version}/${B.shasum}.tgz`)
+    expect(resB.status).toBe(200)
+    expect((await computeDigests(new Uint8Array(await resB.arrayBuffer()))).shasum).toBe(B.shasum)
+
+    // The packument advertises B (last write wins), and B's content URL serves
+    // bytes that hash to the advertised integrity.
+    const dist = await distFor(version)
+    expect(dist.tarball).toBe(`${BASE}/tarballs/${NAME}/${version}/${B.shasum}.tgz`)
+    expect(dist.integrity).toBe(B.integrity)
+    const served = new Uint8Array(await (await SELF.fetch(dist.tarball)).arrayBuffer())
+    expect((await computeDigests(served)).integrity).toBe(dist.integrity)
+
+    await cleanup(version, [A.shasum, B.shasum])
+  })
+
+  it('the packument-advertised content URL always hashes to the advertised integrity', async () => {
+    const sha = 'ca50002'
+    const ref = `commit.${sha}`
+    const version = `0.0.0-commit.${sha}`
+    const pkg = { name: NAME, version }
+
+    const { shasum } = await publishFull(NAME, version, ref, pkg, await makeTarball(pkg, 'only'))
+
+    const dist = await distFor(version)
+    const served = new Uint8Array(await (await SELF.fetch(dist.tarball)).arrayBuffer())
+    expect((await computeDigests(served)).integrity).toBe(dist.integrity)
+
+    await cleanup(version, [shasum])
+  })
+
+  it('migration fallback: an old version-addressed publish serves the current build revalidatable, and a superseded shasum 404s', async () => {
+    const sha = 'ca50003'
+    const ref = `commit.${sha}`
+    const version = `0.0.0-commit.${sha}`
+    const pkg = { name: NAME, version }
+
+    const bytes = await makeTarball(pkg, 'legacy')
+    const { shasum, integrity } = await computeDigests(bytes)
+    // Simulate an OLD (version-addressed) publish action mid-migration: it stored
+    // the bytes at the legacy version key and published this same shasum, but the
+    // CAS object never got written (the new content path is what writes it).
+    await env.STORAGE.put(tarballKey(NAME, version), bytes, {
+      httpMetadata: { contentType: 'application/gzip' },
+    })
+    await publishRegister(NAME, version, ref, pkg, { shasum, integrity })
+
+    // The packument advertises the content URL derived from that shasum.
+    const dist = await distFor(version)
+    expect(dist.tarball).toBe(`${BASE}/tarballs/${NAME}/${version}/${shasum}.tgz`)
+
+    // (a) With no CAS object, the fallback serves the legacy bytes for the CURRENT
+    // build's content URL: 200, bytes hash to the advertised integrity, but NOT
+    // immutable (the legacy key is mutable, so the response must be revalidatable).
+    const res = await SELF.fetch(dist.tarball)
+    expect(res.status).toBe(200)
+    const served = new Uint8Array(await res.arrayBuffer())
+    expect((await computeDigests(served)).integrity).toBe(integrity)
+    expect(res.headers.get('cache-control')).toBe('public, max-age=300')
+    expect(res.headers.get('cache-control')).not.toContain('immutable')
+
+    // (b) A content URL for a DIFFERENT (not-current) 40-hex shasum on this version
+    // 404s: the fallback is gated on meta.shasum === requested shasum, so it never
+    // serves the legacy bytes under some other build's content id.
+    const otherShasum = 'b'.repeat(40)
+    expect(otherShasum).not.toBe(shasum)
+    const other = await SELF.fetch(`${BASE}/tarballs/${NAME}/${version}/${otherShasum}.tgz`)
+    expect(other.status).toBe(404)
+
+    await cleanup(version, [shasum])
+  })
+
+  it('compat redirect: the legacy version URL 302-redirects to the current content URL', async () => {
+    const sha = 'ca50004'
+    const ref = `commit.${sha}`
+    const version = `0.0.0-commit.${sha}`
+    const pkg = { name: NAME, version }
+
+    const { shasum } = await publishFull(NAME, version, ref, pkg, await makeTarball(pkg, 'compat'))
+
+    const res = await SELF.fetch(`${BASE}/tarballs/${NAME}/${version}.tgz`, {
+      redirect: 'manual',
+    })
+    expect(res.status).toBe(302)
+    expect(res.headers.get('location')).toBe(
+      `${BASE}/tarballs/${NAME}/${version}/${shasum}.tgz`,
+    )
+    // The version->build mapping is mutable, so the redirect is not cached.
+    expect(res.headers.get('cache-control')).toBe('no-store')
+
+    await cleanup(version, [shasum])
+  })
+})

--- a/test/unit.test.ts
+++ b/test/unit.test.ts
@@ -171,6 +171,22 @@ describe('parseTarballPath', () => {
     })
   })
 
+  it('parses a content-addressed path (trailing 40-hex shasum)', () => {
+    const shasum = 'a'.repeat(40)
+    expect(
+      parseTarballPath(`/tarballs/vite-plus/0.0.0-commit.a832a55/${shasum}.tgz`),
+    ).toEqual({ name: 'vite-plus', version: '0.0.0-commit.a832a55', shasum })
+    expect(
+      parseTarballPath(
+        `/tarballs/@voidzero-dev/vite-plus-core/0.0.0-commit.a832a55/${shasum}.tgz`,
+      ),
+    ).toEqual({
+      name: '@voidzero-dev/vite-plus-core',
+      version: '0.0.0-commit.a832a55',
+      shasum,
+    })
+  })
+
   it('returns null for non-tarball paths', () => {
     expect(parseTarballPath('/vite-plus')).toBeNull()
     expect(parseTarballPath('/tarballs/vite-plus/0.0.0-pr.1891')).toBeNull()
@@ -382,6 +398,7 @@ describe('validateTarballPath', () => {
 
 describe('buildVersionMetadata', () => {
   it('drops devDependencies, sets dist.tarball/_id/integrity', () => {
+    const shasum = 'a'.repeat(40)
     const meta = buildVersionMetadata(env, 'vite-plus', '0.0.0-pr.1891', {
       packageJson: {
         name: 'vite-plus',
@@ -390,17 +407,34 @@ describe('buildVersionMetadata', () => {
         devDependencies: { typescript: '^5' },
         bin: { vp: './bin/vp' },
       },
-      shasum: 'abc123',
+      shasum,
       integrity: 'sha512-deadbeef',
     })
     expect(meta.devDependencies).toBeUndefined()
     expect(meta.bin).toEqual({ vp: './bin/vp' })
     expect(meta._id).toBe('vite-plus@0.0.0-pr.1891')
+    // With a valid (40-hex) shasum, dist.tarball is the content-addressed URL
+    // (the shasum in the path), so a client fetches the exact advertised build.
+    expect(meta.dist.tarball).toBe(
+      `https://bridge.example.com/tarballs/vite-plus/0.0.0-pr.1891/${shasum}.tgz`,
+    )
+    expect(meta.dist.shasum).toBe(shasum)
+    expect(meta.dist.integrity).toBe('sha512-deadbeef')
+  })
+
+  it('falls back to the version URL when the shasum is not a valid 40-hex digest', () => {
+    // A malformed shasum must not emit a content URL: parseTarballPath only
+    // treats a 40-hex trailing segment as content-addressed, so a bad one would
+    // 404. It falls back to the version URL (which redirects to the current build).
+    const meta = buildVersionMetadata(env, 'vite-plus', '0.0.0-pr.1891', {
+      packageJson: { name: 'vite-plus', version: '0.0.0-pr.1891' },
+      shasum: 'abc123',
+      integrity: 'sha512-deadbeef',
+    })
     expect(meta.dist.tarball).toBe(
       'https://bridge.example.com/tarballs/vite-plus/0.0.0-pr.1891.tgz',
     )
     expect(meta.dist.shasum).toBe('abc123')
-    expect(meta.dist.integrity).toBe('sha512-deadbeef')
   })
 })
 

--- a/test/worker.test.ts
+++ b/test/worker.test.ts
@@ -1,5 +1,6 @@
 import { SELF, env } from 'cloudflare:test'
-import { metaIndexKey, metaKey } from '../src/cache/r2Cache'
+import { casKey, metaIndexKey, metaKey } from '../src/cache/r2Cache'
+import { computeDigests } from '../src/tarball/digests'
 import { cleanupExpiredArtifacts } from '../src/preview/cleanupExpired'
 import { REF_TTL_MS } from '../src/preview/getConfiguredRefs'
 import {
@@ -168,40 +169,66 @@ async function publishAndRegister(body: {
 // The suite's fixture preview ref (`commit.a832a55`), published before each test
 // (idempotent, so it survives storage isolation). Publishing vite-plus + core
 // with their rewritten package.json is exactly what a CI publish stores, so
-// packuments inject the ref the way they do in production.
+// packuments inject the ref the way they do in production. The tarball bytes are
+// uploaded content-addressed (shasum in the path) and published with their REAL
+// shasum/integrity, so `dist.tarball` (the content URL) resolves to real bytes
+// that hash to the advertised integrity, exactly like a CI publish.
 const FIXTURE_VERSION = '0.0.0-commit.a832a55'
-beforeEach(async () => {
-  await publishAndRegister({
-    ref: 'commit.a832a55',
-    packages: [
-      {
-        name: 'vite-plus',
-        version: FIXTURE_VERSION,
-        packageJson: {
-          name: 'vite-plus',
-          version: FIXTURE_VERSION,
-          dependencies: { '@voidzero-dev/vite-plus-core': FIXTURE_VERSION },
-          optionalDependencies: {
-            '@voidzero-dev/vite-plus-darwin-arm64': `0.0.0-commit.${PLATFORM_SHA}`,
-          },
-          bin: { vp: './bin/vp' },
-        },
-        integrity: 'sha512-Zm9vYmFy',
-        shasum: 'a'.repeat(40),
-      },
-      {
-        name: '@voidzero-dev/vite-plus-core',
-        version: FIXTURE_VERSION,
-        packageJson: {
-          name: '@voidzero-dev/vite-plus-core',
-          version: FIXTURE_VERSION,
-          dependencies: { 'vite-plus': FIXTURE_VERSION },
-        },
-        integrity: 'sha512-Y29yZQ',
-        shasum: 'b'.repeat(40),
-      },
-    ],
+const FIXTURE_PKG_JSON: Record<string, Record<string, any>> = {
+  'vite-plus': {
+    name: 'vite-plus',
+    version: FIXTURE_VERSION,
+    dependencies: { '@voidzero-dev/vite-plus-core': FIXTURE_VERSION },
+    optionalDependencies: {
+      '@voidzero-dev/vite-plus-darwin-arm64': `0.0.0-commit.${PLATFORM_SHA}`,
+    },
+    bin: { vp: './bin/vp' },
+  },
+  '@voidzero-dev/vite-plus-core': {
+    name: '@voidzero-dev/vite-plus-core',
+    version: FIXTURE_VERSION,
+    dependencies: { 'vite-plus': FIXTURE_VERSION },
+  },
+}
+// Each fixture build's shasum, recomputed every beforeEach so tests can name the
+// exact content URL (`/tarballs/<name>/<version>/<shasum>.tgz`) the packument
+// advertises.
+const fixtureShasum: Record<string, string> = {}
+
+/**
+ * Upload a real preview tarball to the content-addressed path and return the
+ * digests the packument will advertise for it — the same shape a CI publish
+ * produces (build bytes, hash, PUT to the content path).
+ */
+async function uploadFixtureTarball(
+  name: string,
+  version: string,
+  packageJson: Record<string, any>,
+): Promise<{ shasum: string; integrity: string }> {
+  const bytes = await makeTarball(packageJson)
+  const { shasum, integrity } = await computeDigests(bytes)
+  const up = await SELF.fetch(`${BASE}/-/tarball/${name}/${version}/${shasum}.tgz`, {
+    method: 'PUT',
+    headers: { authorization: 'Bearer test-admin-token' },
+    body: bytes,
   })
+  expect(up.status).toBe(201)
+  return { shasum, integrity }
+}
+
+beforeEach(async () => {
+  const packages = await Promise.all(
+    Object.entries(FIXTURE_PKG_JSON).map(async ([name, packageJson]) => {
+      const { shasum, integrity } = await uploadFixtureTarball(
+        name,
+        FIXTURE_VERSION,
+        packageJson,
+      )
+      fixtureShasum[name] = shasum
+      return { name, version: FIXTURE_VERSION, packageJson, integrity, shasum }
+    }),
+  )
+  await publishAndRegister({ ref: 'commit.a832a55', packages })
 })
 
 describe('packument endpoint', () => {
@@ -224,7 +251,7 @@ describe('packument endpoint', () => {
       '0.0.0-commit.a832a55',
     )
     expect(preview.dist.tarball).toBe(
-      `${BASE}/tarballs/vite-plus/0.0.0-commit.a832a55.tgz`,
+      `${BASE}/tarballs/vite-plus/0.0.0-commit.a832a55/${fixtureShasum['vite-plus']}.tgz`,
     )
     expect(res.headers.get('cache-control')).toContain('max-age=300')
   })
@@ -430,7 +457,7 @@ describe('packument endpoint', () => {
     expect(preview).toBeTruthy()
     expect(preview.dependencies['vite-plus']).toBe('0.0.0-commit.a832a55')
     expect(preview.dist.tarball).toBe(
-      `${BASE}/tarballs/@voidzero-dev/vite-plus-core/0.0.0-commit.a832a55.tgz`,
+      `${BASE}/tarballs/@voidzero-dev/vite-plus-core/0.0.0-commit.a832a55/${fixtureShasum['@voidzero-dev/vite-plus-core']}.tgz`,
     )
     // A synthesized (not-on-npm) packument still needs `time` for the preview,
     // or pnpm errors with ERR_PNPM_MISSING_TIME.
@@ -470,7 +497,9 @@ describe('packument endpoint', () => {
 
   it('injects the version into a platform package packument with os/cpu', async () => {
     // The fixture ref has no darwin meta published, so the platform packument
-    // derives os/cpu from the package name (platformMetaFromName).
+    // derives os/cpu from the package name (platformMetaFromName). With no
+    // published shasum, dist.tarball is the version URL (which the bridge
+    // redirects to the current build), NOT a content URL.
     const res = await SELF.fetch(
       `${BASE}/@voidzero-dev%2Fvite-plus-darwin-arm64`,
       { headers: { accept: 'application/json' } },
@@ -502,15 +531,18 @@ describe('packument endpoint', () => {
     const ver = '0.0.0-commit.cafebabecafebabecafebabecafebabecafebabe'
     const pkg = '@voidzero-dev/vite-plus-darwin-arm64'
     const tarball = await makeTarball({ name: pkg, version: ver, os: ['darwin'], cpu: ['arm64'] })
+    const { shasum } = await computeDigests(tarball)
 
-    const up = await SELF.fetch(`${BASE}/-/tarball/${pkg}/${ver}.tgz`, {
+    // CI uploads content-addressed (shasum in the path); the content URL then
+    // serves those exact bytes.
+    const up = await SELF.fetch(`${BASE}/-/tarball/${pkg}/${ver}/${shasum}.tgz`, {
       method: 'PUT',
       headers: AUTH,
       body: tarball,
     })
     expect(up.status).toBe(201)
 
-    const res = await SELF.fetch(`${BASE}/tarballs/${pkg}/${ver}.tgz`)
+    const res = await SELF.fetch(`${BASE}/tarballs/${pkg}/${ver}/${shasum}.tgz`)
     expect(res.status).toBe(200)
     const bytes = new Uint8Array(await res.arrayBuffer())
     expect(res.headers.get('content-length')).toBe(String(bytes.byteLength))
@@ -536,7 +568,17 @@ describe('packument endpoint', () => {
 
 describe('tarball endpoint', () => {
   it('serves a generated commit tarball with rewritten package.json and immutable cache', async () => {
-    const res = await SELF.fetch(`${BASE}/tarballs/vite-plus/0.0.0-commit.a832a55.tgz`)
+    // The packument advertises the content URL (shasum in the path); fetch that
+    // and confirm it serves the rewritten bytes with immutable caching.
+    const pack = (await (
+      await SELF.fetch(`${BASE}/vite-plus`, { headers: { accept: 'application/json' } })
+    ).json()) as Record<string, any>
+    const tarball = pack.versions[FIXTURE_VERSION].dist.tarball
+    expect(tarball).toBe(
+      `${BASE}/tarballs/vite-plus/0.0.0-commit.a832a55/${fixtureShasum['vite-plus']}.tgz`,
+    )
+
+    const res = await SELF.fetch(tarball)
     expect(res.status).toBe(200)
     expect(res.headers.get('content-type')).toBe('application/gzip')
     expect(res.headers.get('cache-control')).toContain('immutable')
@@ -553,26 +595,29 @@ describe('tarball endpoint', () => {
   })
 
   it('also serves the npm-convention tarball path (/<name>/-/<name>-<version>.tgz)', async () => {
+    // The version-addressed npm-convention path now 302-redirects to the
+    // version's current content URL (the canonical, immutable location).
     const res = await SELF.fetch(
       `${BASE}/vite-plus/-/vite-plus-0.0.0-commit.a832a55.tgz`,
+      { redirect: 'manual' },
     )
-    expect(res.status).toBe(200)
-    expect(res.headers.get('content-type')).toBe('application/gzip')
-
-    const bytes = new Uint8Array(await res.arrayBuffer())
-    const files = await parseTarGzip(bytes)
-    const pkgFile = files.find((f) => f.name === 'package/package.json')
-    const pkg = JSON.parse(new TextDecoder().decode(pkgFile!.data))
-    expect(pkg.name).toBe('vite-plus')
-    expect(pkg.version).toBe('0.0.0-commit.a832a55')
+    expect(res.status).toBe(302)
+    expect(res.headers.get('location')).toBe(
+      `${BASE}/tarballs/vite-plus/0.0.0-commit.a832a55/${fixtureShasum['vite-plus']}.tgz`,
+    )
+    // The mapping is mutable (last write wins), so the redirect is not cached.
+    expect(res.headers.get('cache-control')).toBe('no-store')
   })
 
   it('serves the npm-convention path for a scoped preview package', async () => {
     const res = await SELF.fetch(
       `${BASE}/@voidzero-dev/vite-plus-core/-/vite-plus-core-0.0.0-commit.a832a55.tgz`,
+      { redirect: 'manual' },
     )
-    expect(res.status).toBe(200)
-    expect(res.headers.get('content-type')).toBe('application/gzip')
+    expect(res.status).toBe(302)
+    expect(res.headers.get('location')).toBe(
+      `${BASE}/tarballs/@voidzero-dev/vite-plus-core/0.0.0-commit.a832a55/${fixtureShasum['@voidzero-dev/vite-plus-core']}.tgz`,
+    )
   })
 
   it('redirects an npm-convention path to npm for non-preview packages/versions', async () => {
@@ -623,12 +668,11 @@ describe('integrity', () => {
     const ver = `0.0.0-commit.${PLATFORM_SHA}`
     const pkg = '@voidzero-dev/vite-plus-darwin-arm64'
     const tarball = await makeTarball({ name: pkg, version: ver, os: ['darwin'], cpu: ['arm64'] })
-    const integrity = `sha512-${btoa(
-      String.fromCharCode(...new Uint8Array(await crypto.subtle.digest('SHA-512', tarball))),
-    )}`
+    const { shasum, integrity } = await computeDigests(tarball)
 
-    // CI uploads the tarball, then publishes its meta + registers the ref.
-    const up = await SELF.fetch(`${BASE}/-/tarball/${pkg}/${ver}.tgz`, {
+    // CI uploads the tarball content-addressed (shasum in the path), then
+    // publishes its meta + registers the ref.
+    const up = await SELF.fetch(`${BASE}/-/tarball/${pkg}/${ver}/${shasum}.tgz`, {
       method: 'PUT',
       headers: AUTH,
       body: tarball,
@@ -642,27 +686,27 @@ describe('integrity', () => {
           version: ver,
           packageJson: { name: pkg, version: ver, os: ['darwin'], cpu: ['arm64'] },
           integrity,
-          shasum: '',
+          shasum,
         },
       ],
     })
     expect(pub.status).toBe(201)
 
-    // The tarball serves from R2, and the packument advertises an integrity that
-    // matches those exact served bytes.
-    const tres = await SELF.fetch(`${BASE}/tarballs/${pkg}/${ver}.tgz`)
-    expect(tres.status).toBe(200)
-    const served = new Uint8Array(await tres.arrayBuffer())
-    const servedIntegrity = `sha512-${btoa(
-      String.fromCharCode(...new Uint8Array(await crypto.subtle.digest('SHA-512', served))),
-    )}`
-    expect(servedIntegrity).toBe(integrity)
-
+    // The packument advertises the content URL (shasum in the path)...
     const pres = await SELF.fetch(`${BASE}/@voidzero-dev%2Fvite-plus-darwin-arm64`, {
       headers: { accept: 'application/vnd.npm.install-v1+json' },
     })
     const body = (await pres.json()) as Record<string, any>
-    expect(body.versions[ver].dist.integrity).toBe(integrity)
+    const dist = body.versions[ver].dist
+    expect(dist.integrity).toBe(integrity)
+    expect(dist.tarball).toBe(`${BASE}/tarballs/${pkg}/${ver}/${shasum}.tgz`)
+
+    // ...and the bytes fetched from that content URL hash to the advertised
+    // integrity (the invariant both production incidents violated).
+    const tres = await SELF.fetch(dist.tarball)
+    expect(tres.status).toBe(200)
+    const served = new Uint8Array(await tres.arrayBuffer())
+    expect((await computeDigests(served)).integrity).toBe(integrity)
   })
 })
 
@@ -1061,6 +1105,49 @@ describe('admin: purge', () => {
     })
     expect((await readIndex())?.[ver]).toBeUndefined()
   })
+
+  it('removes EVERY content-addressed build of the version, not just the current one', async () => {
+    const sha = 'ba5eba11'
+    const ref = `commit.${sha}`
+    const version = `0.0.0-commit.${sha}`
+    const publish = (d: { shasum: string; integrity: string }) =>
+      publishAndRegister({
+        ref,
+        packages: [
+          {
+            name: 'vite-plus',
+            version,
+            packageJson: { name: 'vite-plus', version },
+            integrity: d.integrity,
+            shasum: d.shasum,
+          },
+        ],
+      })
+
+    // Build A, then republish the same version with different bytes -> build B.
+    // Both CAS objects coexist (last-write-wins only moves the meta/index).
+    const A = await uploadFixtureTarball('vite-plus', version, { name: 'vite-plus', version, marker: 'A' })
+    await publish(A)
+    const B = await uploadFixtureTarball('vite-plus', version, { name: 'vite-plus', version, marker: 'B' })
+    await publish(B)
+    expect(A.shasum).not.toBe(B.shasum)
+
+    // Both builds are installable before the purge.
+    expect((await SELF.fetch(`${BASE}/tarballs/vite-plus/${version}/${A.shasum}.tgz`)).status).toBe(200)
+    expect((await SELF.fetch(`${BASE}/tarballs/vite-plus/${version}/${B.shasum}.tgz`)).status).toBe(200)
+
+    const purged = await SELF.fetch(`${BASE}/-/purge`, {
+      method: 'POST',
+      headers: { ...AUTH, 'content-type': 'application/json' },
+      body: JSON.stringify({ package: 'vite-plus', version }),
+    })
+    expect(purged.status).toBe(200)
+
+    // Purge lists casVersionPrefix and deletes ALL builds, so the superseded (A)
+    // build's content URL 404s too, not just the current (B) one.
+    expect((await SELF.fetch(`${BASE}/tarballs/vite-plus/${version}/${A.shasum}.tgz`)).status).toBe(404)
+    expect((await SELF.fetch(`${BASE}/tarballs/vite-plus/${version}/${B.shasum}.tgz`)).status).toBe(404)
+  })
 })
 
 describe('admin: publish', () => {
@@ -1223,21 +1310,25 @@ describe('health', () => {
 })
 
 describe('cleanup of expired artifacts (scheduled)', () => {
-  it('deletes per-version meta + tarball past the ref TTL', async () => {
+  it('deletes per-version meta + tarball + cas bytes past the ref TTL', async () => {
     await env.STORAGE.put('meta/vite-plus/0.0.0-commit.old00001.json', '{}')
     await env.STORAGE.put('tarball/vite-plus/0.0.0-commit.old00001.tgz', 'x')
+    // A content-addressed (cas) object is swept the same age-based way.
+    const casObjKey = casKey('vite-plus', '0.0.0-commit.old00001', 'a'.repeat(40))
+    await env.STORAGE.put(casObjKey, 'x')
     // A future "now" makes every object older than the TTL, so all are expired.
     const { deleted } = await cleanupExpiredArtifacts(
       env,
       Date.now() + 2 * REF_TTL_MS,
     )
-    expect(deleted).toBeGreaterThanOrEqual(2)
+    expect(deleted).toBeGreaterThanOrEqual(3)
     expect(
       await env.STORAGE.get('meta/vite-plus/0.0.0-commit.old00001.json'),
     ).toBeNull()
     expect(
       await env.STORAGE.get('tarball/vite-plus/0.0.0-commit.old00001.tgz'),
     ).toBeNull()
+    expect(await env.STORAGE.get(casObjKey)).toBeNull()
   })
 
   it('keeps artifacts within the TTL and never touches the indexes', async () => {


### PR DESCRIPTION
## Problem

Two CI runs of the same commit `0.0.0-commit.<sha>` produce different tarball bytes whenever the vite-plus build is not byte-reproducible (`pnpm pack` itself is deterministic, verified). The bridge stored the bytes at a version-addressed key and advertised a version-addressed `dist.tarball`, so a republish overwrote the bytes while the meta could still point at a different run: pnpm hit `ERR_PNPM_TARBALL_INTEGRITY`, and the `immutable` edge cache could keep serving the poisoned bytes.

Observed live for `vite-plus@0.0.0-commit.fd1ae7ea...`: packument integrity `sha512-O9C+Ac...`, served tarball `sha512-4hg5CR...`.

## Fix

Put the content hash in the URL and the storage key:

- `dist.tarball` = `/tarballs/<name>/<version>/<shasum>.tgz`
- bytes at `cas/<name>/<shasum>.tgz`

A distinct build gets a distinct URL, so a client always fetches the exact build its packument advertised, and two builds of the same version coexist instead of overwriting each other. `immutable` caching is correct again (the URL is content-bound), and `/-/publish` stays last-write-wins: no write-once, no revalidation, no special cleanup.

The action uploads to the content path with the build shasum. The old `/tarballs/<name>/<version>.tgz` still resolves: it redirects (no-store) to the current build's content URL, or serves pre-CAS bytes for a version published before this change.

## Verification

- `test/republish-integrity.test.ts`: a republish with different bytes keeps both content URLs serving their own bytes; the packument-advertised content URL always hashes to the advertised integrity; migration and the compat redirect.
- Full suite 100/100, typecheck clean, action bundle rebuilt.

## Notes

- Activation needs vite-plus to bump the action pin to a ref containing this change (the action uploads to the content path). The serve side is back-compat: old version-addressed URLs still resolve.
- `fd1ae7ea...` won't self-heal; purge and republish that sha.
