### PR TITLE
Log the content-addressed tarball URL and integrity per published package

### DIFF
--- a/.github/actions/publish-preview/dist/index.mjs
+++ b/.github/actions/publish-preview/dist/index.mjs
@@ -690,7 +690,8 @@ async function main() {
     };
     await post("/-/publish", { ref, packages: [pkg] }, `publish ${manifest.name}`);
     console.log(
-      `  \u2713 ${manifest.name}@${version} (${build.tarball.byteLength} bytes, from ${relative(cwd, dir)})`
+      `  \u2713 ${manifest.name}@${version} (${build.tarball.byteLength} bytes, from ${relative(cwd, dir)})
+      ${bridge}/tarballs/${manifest.name}/${version}/${build.shasum}.tgz  (${build.integrity})`
     );
   }
   await post("/-/register", { ref, prUrl }, "register ref");

--- a/.github/actions/publish-preview/src/index.ts
+++ b/.github/actions/publish-preview/src/index.ts
@@ -162,8 +162,12 @@ async function main(): Promise<void> {
       shasum: build.shasum,
     }
     await post('/-/publish', { ref, packages: [pkg] }, `publish ${manifest.name}`)
+    // Log the content-addressed tarball URL (the shasum lives in its path) and
+    // the integrity, so an install mismatch is debuggable straight from the CI
+    // log: fetch the URL, hash it, and compare against the integrity here.
     console.log(
-      `  ✓ ${manifest.name}@${version} (${build.tarball.byteLength} bytes, from ${relative(cwd, dir)})`,
+      `  ✓ ${manifest.name}@${version} (${build.tarball.byteLength} bytes, from ${relative(cwd, dir)})\n` +
+        `      ${bridge}/tarballs/${manifest.name}/${version}/${build.shasum}.tgz  (${build.integrity})`,
     )
   }
 


### PR DESCRIPTION
The publish action logged only the byte count per package, so when an install hit a content URL / integrity mismatch there was nothing in the CI log to check it against (noticed on a vite-plus preview build).

Now each package logs its exact content URL (the shasum is in the path) and integrity:

```
  ✓ vite-plus@0.0.0-commit.<sha> (1019409 bytes, from packages/cli)
      https://registry-bridge.viteplus.dev/tarballs/vite-plus/0.0.0-commit.<sha>/<shasum>.tgz  (sha512-...)
```

So next time you can fetch that URL, hash it, and compare against the integrity straight from the log. Logging only; no behavior change. Action bundle rebuilt.