### PR TITLE
Set the OIDC publishing vars for production

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -5,3 +5,23 @@
 # Public origin of the deployed bridge (the Void platform URL). Update this if a
 # custom domain is later attached with `void domain add`.
 PUBLIC_BASE_URL=https://registry-bridge.viteplus.dev
+
+# GitHub Actions OIDC publishing (RFC 0002). Public identifiers, not secrets.
+# All four must be set together; a partial config returns 503 for every publish,
+# including admin-token ones.
+#
+# The numeric ids are what anchor trust: OIDC_TRUSTED_WORKFLOWS embeds a
+# repository NAME, and names can be renamed, transferred, or released and
+# reclaimed by someone else. Read them back with:
+#   gh api repos/voidzero-dev/vite-plus --jq '{repo: .id, owner: .owner.id}'
+#
+# NOTE: `pnpm deploy:staging` deploys with the same `void deploy`, so staging
+# inherits this file (which is also why PUBLIC_BASE_URL above points at prod).
+# Staging therefore shares this audience and allowlist. That is not an
+# escalation while both are identical, but it does mean staging cannot be given
+# a looser allowlist for testing without that workflow also being able to
+# publish to production.
+OIDC_AUDIENCE=https://registry-bridge.viteplus.dev
+OIDC_TRUSTED_WORKFLOWS=voidzero-dev/vite-plus/.github/workflows/publish-preview-register.yml@refs/heads/main
+OIDC_TRUSTED_REPOSITORY_ID=943901988
+OIDC_TRUSTED_OWNER_ID=149750581

--- a/env.ts
+++ b/env.ts
@@ -16,4 +16,16 @@ export default defineEnv({
   WORKSPACE_PACKAGES: string(),
   // Bearer token guarding the admin endpoints. Secret: `void secret put ADMIN_TOKEN`.
   ADMIN_TOKEN: string().secret().optional(),
+  // GitHub Actions OIDC publishing (RFC 0002). NOT secrets: all four hold
+  // public identifiers, and the verification key is GitHub's public JWKS, so
+  // they live in `.env.production` rather than `void secret put`.
+  //
+  // Optional as a group: leaving all four unset disables the OIDC path and
+  // leaves admin-token publishing untouched. Setting only SOME of them is
+  // rejected at request time, so a half-configured deploy fails loudly instead
+  // of silently refusing every token.
+  OIDC_AUDIENCE: string().optional(),
+  OIDC_TRUSTED_WORKFLOWS: string().optional(),
+  OIDC_TRUSTED_REPOSITORY_ID: string().optional(),
+  OIDC_TRUSTED_OWNER_ID: string().optional(),
 })


### PR DESCRIPTION
Fixes an omission from #86: the four `OIDC_*` vars were declared in `src/config.ts`'s `Env` interface but never in `env.ts` or `.env.production`, so they are absent at runtime and the OIDC path has been disabled since deploy.

**They are not secrets.** All four hold public identifiers and the verification key is GitHub's public JWKS, so per the README's configuration model they belong in `env.ts` plus the committed `.env.production`, not `void secret put`. I had been describing this as needing Void auth, which was wrong; it is a code change and should have shipped with #86.

Declared optional as a group. All four unset disables OIDC and leaves admin-token publishing untouched, which is production's current state. Setting only some is already rejected at request time with a 503 naming the missing var.

```
OIDC_AUDIENCE=https://registry-bridge.viteplus.dev
OIDC_TRUSTED_WORKFLOWS=voidzero-dev/vite-plus/.github/workflows/publish-preview-register.yml@refs/heads/main
OIDC_TRUSTED_REPOSITORY_ID=943901988
OIDC_TRUSTED_OWNER_ID=149750581
```

The numeric ids are what anchor trust, since `OIDC_TRUSTED_WORKFLOWS` embeds a repository *name* and names can be renamed, transferred, or reclaimed. Read back from `gh api repos/voidzero-dev/vite-plus`.

## One wrinkle worth knowing

`pnpm deploy:staging` runs the same `void deploy`, so staging inherits `.env.production` — which is also why `PUBLIC_BASE_URL` there already points at prod. Staging will therefore share this audience and allowlist.

That is not an escalation while the two are identical: only the vite-plus register workflow can mint an acceptable token either way. But it does mean staging cannot be given a *looser* allowlist to smoke-test OIDC without that workflow also being able to publish to production, so the "test OIDC against staging first" plan I suggested does not work as described. Recorded in a comment next to the values rather than left to be rediscovered.

## Effect of merging

Deploying this turns OIDC on in production. Nothing changes for existing publishes: vite-plus `main` still uses the admin-token path, and the admin path is unaffected either way. It simply makes voidzero-dev/vite-plus#2387 able to work once merged.

205 tests pass, typecheck clean.
