### PR TITLE
Return 401, not 500, for a token segment that is not valid UTF-8

### DIFF
--- a/src/security/oidc.ts
+++ b/src/security/oidc.ts
@@ -133,7 +133,16 @@ function base64UrlToBytes(segment: string, label: string): Uint8Array {
   // atob wants canonical padding; segment length %4 === 1 is never valid.
   const pad = b64.length % 4
   if (pad === 1) throw new HttpError(401, `Malformed token (${label} length)`)
-  const binary = atob(pad ? b64 + '='.repeat(4 - pad) : b64)
+  let binary: string
+  try {
+    binary = atob(pad ? b64 + '='.repeat(4 - pad) : b64)
+  } catch {
+    // Defensive: the charset test and the length check above should already
+    // exclude everything atob rejects, so this is not reachable today. It is
+    // here so a future change to either check cannot turn a bad token into a
+    // 500, which is exactly how the UTF-8 case below reached production.
+    throw new HttpError(401, `Malformed token (${label} is not base64url)`)
+  }
   const bytes = new Uint8Array(binary.length)
   for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i)
   return bytes
@@ -147,11 +156,18 @@ function decodeJsonSegment(
   if (segment.length > maxChars) {
     throw new HttpError(401, `Malformed token (${label} too large)`)
   }
-  // `fatal` so invalid UTF-8 throws here instead of silently becoming U+FFFD
-  // inside a claim value.
-  const text = new TextDecoder('utf-8', { fatal: true, ignoreBOM: false }).decode(
-    base64UrlToBytes(segment, label),
-  )
+  // `fatal` so invalid UTF-8 throws instead of silently becoming U+FFFD inside
+  // a claim value. It throws a plain TypeError, so it has to be converted here:
+  // letting it escape turns a garbage token into a 500 rather than a 401.
+  // Base64url's alphabet says nothing about whether the bytes are valid UTF-8,
+  // so this is reachable from any well-formed-looking segment.
+  const bytes = base64UrlToBytes(segment, label)
+  let text: string
+  try {
+    text = new TextDecoder('utf-8', { fatal: true, ignoreBOM: false }).decode(bytes)
+  } catch {
+    throw new HttpError(401, `Malformed token (${label} is not valid UTF-8)`)
+  }
   let parsed: unknown
   try {
     parsed = JSON.parse(text)

--- a/test/oidc.test.ts
+++ b/test/oidc.test.ts
@@ -329,6 +329,15 @@ describe('OIDC token parsing bounds (SR-3)', () => {
     expect(jwksFetches).toBe(0)
   })
 
+  it('rejects a segment whose bytes are not valid UTF-8', async () => {
+    // Found in production: `aaa.bbb.ccc` returned 500, not 401. "aaa" is a
+    // legal base64url segment, but it decodes to 0x69 0xa6, which is invalid
+    // UTF-8, and TextDecoder({fatal}) throws a plain TypeError. The base64url
+    // alphabet says nothing about UTF-8 validity, so this is reachable from
+    // any well-formed-looking token.
+    await reject('aaa.bbb.ccc', /not valid UTF-8/)
+  })
+
   it('rejects a header that decodes to a non-object', async () => {
     await reject(`${b64url('"a string"')}.bb.cc`, /not an object/)
   })


### PR DESCRIPTION
Found by probing production after #90 turned OIDC on. `aaa.bbb.ccc` answers **500 Internal error** instead of 401:

```
$ curl -X POST -H 'authorization: Bearer aaa.bbb.ccc' .../-/publish
{"error":"Internal error"}
```

`aaa` is a legal base64url segment, but it decodes to `0x69 0xa6`, which is invalid UTF-8, and `TextDecoder({fatal: true})` throws a plain `TypeError`. That escaped `decodeJsonSegment` (only `JSON.parse` was guarded), so it missed the `HttpError` branch in the router and became a 500. The base64url alphabet says nothing about whether the decoded bytes are valid UTF-8, so this is reachable from any well-formed-looking token.

No security impact, since the token is rejected either way, but an unauthenticated caller can produce 500s at will, which is noise in error monitoring and the wrong signal about which layer refused.

The existing tests missed it because every fixture segment happened to hold valid UTF-8. Added one that does not.

Also wraps `atob`, though that path is **not reachable today**: the charset test and length check already exclude everything it would reject. Marked defensive in a comment rather than covered by a test asserting a case that cannot occur.

## Incidentally, this confirms OIDC is live

The same probe distinguishes configured from unconfigured, which is the check I could not make after #86:

| token | before #90 | after #90 |
| --- | --- | --- |
| `aaa.bbb.ccc` | `Unauthorized` | reaches the verifier (this bug) |
| well-formed header, bogus signer | `Unauthorized` | `Unknown token signing key` |
| `notatoken` | `Unauthorized` | `Unauthorized` |

206 tests pass, typecheck clean.
