### PR TITLE
fix: retry R2 get once on transient InternalError (10001)

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "vite": "^8.1.0",
     "vitest": "^4.1.0",
     "void": "^0.10.5",
-    "wrangler": "^4.105.0"
+    "wrangler": "^4.121.0"
   },
   "devEngines": {
     "packageManager": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -216,28 +216,28 @@ importers:
     devDependencies:
       '@cloudflare/vitest-pool-workers':
         specifier: ^0.20.0
-        version: 0.20.3(@cloudflare/workers-types@4.20260702.1)(@vitest/runner@4.1.10)(@vitest/snapshot@4.1.10)(vitest@4.1.10(@types/node@24.13.3)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(tsx@4.23.12)))
+        version: 0.20.3(@cloudflare/workers-types@4.20260702.1)(@vitest/runner@4.1.10)(@vitest/snapshot@4.1.10)(vitest@4.1.10(@types/node@24.13.3)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(tsx@4.23.12)))
       '@types/node':
         specifier: ^24.13.2
         version: 24.13.3
       esbuild:
         specifier: ^0.28.1
-        version: 0.28.1
+        version: 0.28.2
       typescript:
         specifier: ^7.0.0
         version: 7.0.2
       vite:
         specifier: ^8.1.0
-        version: 8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(tsx@4.23.12)
+        version: 8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(tsx@4.23.12)
       vitest:
         specifier: ^4.1.0
-        version: 4.1.10(@types/node@24.13.3)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(tsx@4.23.12))
+        version: 4.1.10(@types/node@24.13.3)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(tsx@4.23.12))
       void:
         specifier: ^0.10.5
-        version: 0.10.12(arktype@2.2.1)(kysely@0.29.5)(valibot@1.4.1(typescript@7.0.2))(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(tsx@4.23.12))(vitest@4.1.10(@types/node@24.13.3)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(tsx@4.23.12)))(zod@4.4.3)
+        version: 0.10.12(arktype@2.2.1)(kysely@0.29.5)(valibot@1.4.1(typescript@7.0.2))(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(tsx@4.23.12))(vitest@4.1.10(@types/node@24.13.3)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(tsx@4.23.12)))(zod@4.4.3)
       wrangler:
-        specifier: ^4.105.0
-        version: 4.120.0(@cloudflare/workers-types@4.20260702.1)
+        specifier: ^4.121.0
+        version: 4.121.0(@cloudflare/workers-types@4.20260702.1)
 
 packages:
 
@@ -1864,9 +1864,6 @@ packages:
   error-stack-parser-es@1.0.5:
     resolution: {integrity: sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA==}
 
-  es-module-lexer@2.3.0:
-    resolution: {integrity: sha512-KLdwQm2NvGLDkQDCGvmiQrhkd0JbMzXthwQAUgWjQuQdBLFa3eiBP5arXZyA+f8x+x7OXgud6bq2rxjGtHV2tw==}
-
   es-module-lexer@2.3.1:
     resolution: {integrity: sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==}
 
@@ -2261,10 +2258,6 @@ packages:
     resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
     engines: {node: '>=12.0.0'}
 
-  tinyrainbow@3.1.0:
-    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
-    engines: {node: '>=14.0.0'}
-
   tinyrainbow@3.1.1:
     resolution: {integrity: sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==}
     engines: {node: '>=14.0.0'}
@@ -2434,6 +2427,16 @@ packages:
       '@cloudflare/workers-types':
         optional: true
 
+  wrangler@4.121.0:
+    resolution: {integrity: sha512-dcARWk6CyaD0vJBSLjJn4K2yo+mYko73hzryq+t/9DXnyAq877RWIMl7uOMcDKs5dDXdoickNhZTKxBYT9XKsA==}
+    engines: {node: '>=22.0.0'}
+    hasBin: true
+    peerDependencies:
+      '@cloudflare/workers-types': ^5.20260804.1
+    peerDependenciesMeta:
+      '@cloudflare/workers-types':
+        optional: true
+
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
@@ -2552,27 +2555,27 @@ snapshots:
     optionalDependencies:
       workerd: 1.20260804.1
 
-  '@cloudflare/vite-plugin@1.51.3(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(tsx@4.23.12))(wrangler@4.120.0(@cloudflare/workers-types@4.20260702.1))':
+  '@cloudflare/vite-plugin@1.51.3(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(tsx@4.23.12))(wrangler@4.121.0(@cloudflare/workers-types@4.20260702.1))':
     dependencies:
       '@cloudflare/unenv-preset': 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260804.1)
       miniflare: 5.20260804.1-alpha
       unenv: 2.0.0-rc.24
-      vite: 8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(tsx@4.23.12)
+      vite: 8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(tsx@4.23.12)
       workerd: 1.20260804.1
-      wrangler: 4.120.0(@cloudflare/workers-types@4.20260702.1)
+      wrangler: 4.121.0(@cloudflare/workers-types@4.20260702.1)
       ws: 8.21.0
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
 
-  '@cloudflare/vitest-pool-workers@0.20.3(@cloudflare/workers-types@4.20260702.1)(@vitest/runner@4.1.10)(@vitest/snapshot@4.1.10)(vitest@4.1.10(@types/node@24.13.3)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(tsx@4.23.12)))':
+  '@cloudflare/vitest-pool-workers@0.20.3(@cloudflare/workers-types@4.20260702.1)(@vitest/runner@4.1.10)(@vitest/snapshot@4.1.10)(vitest@4.1.10(@types/node@24.13.3)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(tsx@4.23.12)))':
     dependencies:
       '@vitest/runner': 4.1.10
       '@vitest/snapshot': 4.1.10
       cjs-module-lexer: 1.2.3
       esbuild: 0.28.1
       miniflare: 5.20260801.1-alpha
-      vitest: 4.1.10(@types/node@24.13.3)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(tsx@4.23.12))
+      vitest: 4.1.10(@types/node@24.13.3)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(tsx@4.23.12))
       wrangler: 4.120.0(@cloudflare/workers-types@4.20260702.1)
       zod: 4.4.3
     transitivePeerDependencies:
@@ -3253,15 +3256,15 @@ snapshots:
       '@vitest/spy': 4.1.10
       '@vitest/utils': 4.1.10
       chai: 6.2.2
-      tinyrainbow: 3.1.0
+      tinyrainbow: 3.1.1
 
-  '@vitest/mocker@4.1.10(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(tsx@4.23.12))':
+  '@vitest/mocker@4.1.10(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(tsx@4.23.12))':
     dependencies:
       '@vitest/spy': 4.1.10
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(tsx@4.23.12)
+      vite: 8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(tsx@4.23.12)
 
   '@vitest/pretty-format@4.1.10':
     dependencies:
@@ -3303,7 +3306,7 @@ snapshots:
 
   base64-js@1.5.1: {}
 
-  better-auth@1.6.27(@cloudflare/workers-types@4.20260702.1)(better-sqlite3@12.11.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260702.1)(better-sqlite3@12.11.1)(kysely@0.29.5)(pg@8.22.0))(pg@8.22.0)(vitest@4.1.10(@types/node@24.13.3)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(tsx@4.23.12))):
+  better-auth@1.6.27(@cloudflare/workers-types@4.20260702.1)(better-sqlite3@12.11.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260702.1)(better-sqlite3@12.11.1)(kysely@0.29.5)(pg@8.22.0))(pg@8.22.0)(vitest@4.1.10(@types/node@24.13.3)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(tsx@4.23.12))):
     dependencies:
       '@better-auth/core': 1.6.27(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260702.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.8)(kysely@0.29.5)(nanostores@1.4.2)
       '@better-auth/drizzle-adapter': 1.6.27(@better-auth/core@1.6.27(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260702.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.8)(kysely@0.29.5)(nanostores@1.4.2))(@better-auth/utils@0.4.2)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260702.1)(better-sqlite3@12.11.1)(kysely@0.29.5)(pg@8.22.0))
@@ -3327,7 +3330,7 @@ snapshots:
       drizzle-kit: 0.31.10
       drizzle-orm: 0.45.2(@cloudflare/workers-types@4.20260702.1)(better-sqlite3@12.11.1)(kysely@0.29.5)(pg@8.22.0)
       pg: 8.22.0
-      vitest: 4.1.10(@types/node@24.13.3)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(tsx@4.23.12))
+      vitest: 4.1.10(@types/node@24.13.3)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(tsx@4.23.12))
     transitivePeerDependencies:
       - '@cloudflare/workers-types'
       - '@opentelemetry/api'
@@ -3423,8 +3426,6 @@ snapshots:
       once: 1.4.0
 
   error-stack-parser-es@1.0.5: {}
-
-  es-module-lexer@2.3.0: {}
 
   es-module-lexer@2.3.1: {}
 
@@ -3907,8 +3908,6 @@ snapshots:
       fdir: 6.5.0(picomatch@4.0.5)
       picomatch: 4.0.5
 
-  tinyrainbow@3.1.0: {}
-
   tinyrainbow@3.1.1: {}
 
   tslib@2.8.1:
@@ -3961,7 +3960,7 @@ snapshots:
     optionalDependencies:
       typescript: 7.0.2
 
-  vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(tsx@4.23.12):
+  vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(tsx@4.23.12):
     dependencies:
       lightningcss: 1.33.0
       picomatch: 4.0.5
@@ -3970,20 +3969,20 @@ snapshots:
       tinyglobby: 0.2.17
     optionalDependencies:
       '@types/node': 24.13.3
-      esbuild: 0.28.1
+      esbuild: 0.28.2
       fsevents: 2.3.3
       tsx: 4.23.12
 
-  vitest@4.1.10(@types/node@24.13.3)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(tsx@4.23.12)):
+  vitest@4.1.10(@types/node@24.13.3)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(tsx@4.23.12)):
     dependencies:
       '@vitest/expect': 4.1.10
-      '@vitest/mocker': 4.1.10(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(tsx@4.23.12))
+      '@vitest/mocker': 4.1.10(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(tsx@4.23.12))
       '@vitest/pretty-format': 4.1.10
       '@vitest/runner': 4.1.10
       '@vitest/snapshot': 4.1.10
       '@vitest/spy': 4.1.10
       '@vitest/utils': 4.1.10
-      es-module-lexer: 2.3.0
+      es-module-lexer: 2.3.1
       expect-type: 1.4.0
       magic-string: 0.30.21
       obug: 2.1.3
@@ -3993,22 +3992,22 @@ snapshots:
       tinybench: 2.9.0
       tinyexec: 1.2.4
       tinyglobby: 0.2.17
-      tinyrainbow: 3.1.0
-      vite: 8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(tsx@4.23.12)
+      tinyrainbow: 3.1.1
+      vite: 8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(tsx@4.23.12)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 24.13.3
     transitivePeerDependencies:
       - msw
 
-  void@0.10.12(arktype@2.2.1)(kysely@0.29.5)(valibot@1.4.1(typescript@7.0.2))(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(tsx@4.23.12))(vitest@4.1.10(@types/node@24.13.3)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(tsx@4.23.12)))(zod@4.4.3):
+  void@0.10.12(arktype@2.2.1)(kysely@0.29.5)(valibot@1.4.1(typescript@7.0.2))(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(tsx@4.23.12))(vitest@4.1.10(@types/node@24.13.3)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(tsx@4.23.12)))(zod@4.4.3):
     dependencies:
       '@cloudflare/sandbox': 0.12.5
-      '@cloudflare/vite-plugin': 1.51.3(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(tsx@4.23.12))(wrangler@4.120.0(@cloudflare/workers-types@4.20260702.1))
+      '@cloudflare/vite-plugin': 1.51.3(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(tsx@4.23.12))(wrangler@4.121.0(@cloudflare/workers-types@4.20260702.1))
       '@cloudflare/workers-types': 4.20260702.1
       '@hono/oauth-providers': 0.8.7(hono@4.13.1)
       '@napi-rs/keyring': 1.3.0
-      better-auth: 1.6.27(@cloudflare/workers-types@4.20260702.1)(better-sqlite3@12.11.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260702.1)(better-sqlite3@12.11.1)(kysely@0.29.5)(pg@8.22.0))(pg@8.22.0)(vitest@4.1.10(@types/node@24.13.3)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(tsx@4.23.12)))
+      better-auth: 1.6.27(@cloudflare/workers-types@4.20260702.1)(better-sqlite3@12.11.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260702.1)(better-sqlite3@12.11.1)(kysely@0.29.5)(pg@8.22.0))(pg@8.22.0)(vitest@4.1.10(@types/node@24.13.3)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(tsx@4.23.12)))
       better-sqlite3: 12.11.1
       blake3-jit: 1.1.0
       drizzle-arktype: 0.1.3(arktype@2.2.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260702.1)(better-sqlite3@12.11.1)(kysely@0.29.5)(pg@8.22.0))
@@ -4022,8 +4021,8 @@ snapshots:
       jsonc-parser: 3.3.1
       pg: 8.22.0
       proper-lockfile: 4.1.2
-      vite: 8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(tsx@4.23.12)
-      wrangler: 4.120.0(@cloudflare/workers-types@4.20260702.1)
+      vite: 8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(tsx@4.23.12)
+      wrangler: 4.121.0(@cloudflare/workers-types@4.20260702.1)
     optionalDependencies:
       arktype: 2.2.1
       valibot: 1.4.1(typescript@7.0.2)
@@ -4105,6 +4104,23 @@ snapshots:
       path-to-regexp: 6.3.0
       unenv: 2.0.0-rc.24
       workerd: 1.20260801.1
+    optionalDependencies:
+      '@cloudflare/workers-types': 4.20260702.1
+      fsevents: 2.3.3
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  wrangler@4.121.0(@cloudflare/workers-types@4.20260702.1):
+    dependencies:
+      '@cloudflare/kv-asset-handler': 0.5.0
+      '@cloudflare/unenv-preset': 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260804.1)
+      blake3-wasm: 2.1.5
+      esbuild: 0.28.1
+      miniflare: 5.20260804.1-alpha
+      path-to-regexp: 6.3.0
+      unenv: 2.0.0-rc.24
+      workerd: 1.20260804.1
     optionalDependencies:
       '@cloudflare/workers-types': 4.20260702.1
       fsevents: 2.3.3

--- a/src/app.ts
+++ b/src/app.ts
@@ -50,6 +50,7 @@ import {
   tarballUrl,
 } from './cache/r2Cache'
 import { kvCachedText } from './cache/kvCache'
+import { describeError } from './util/errors'
 import {
   assertPrUrlInRepository,
   requireAdmin,
@@ -527,7 +528,10 @@ app.get('*', async (c) => {
           )
           time[ref.version] = preview.publishedAt ?? UNPUBLISHED_PREVIEW_TIME
         } catch (err) {
-          console.warn(`Failed to inject preview ref ${ref.version}:`, err)
+          console.warn(
+            `Failed to inject preview ref ${ref.version} into ${name}:`,
+            describeError(err),
+          )
         }
       }),
     )
@@ -555,7 +559,7 @@ app.onError((err, c) => {
   if (err instanceof HttpError) {
     return c.json({ error: err.message }, err.status as ContentfulStatusCode)
   }
-  console.error('Unhandled error:', err)
+  console.error('Unhandled error:', describeError(err))
   return c.json({ error: 'Internal error' }, 500)
 })
 

--- a/src/cache/r2Cas.ts
+++ b/src/cache/r2Cas.ts
@@ -1,4 +1,5 @@
 import type { Env } from '../config'
+import { r2Get } from './r2Get'
 
 const MAX_CAS_ATTEMPTS = 6
 
@@ -11,7 +12,7 @@ export async function readR2Json<T extends object>(
   env: Env,
   key: string,
 ): Promise<{ value: T; etag: string | null }> {
-  const obj = await env.STORAGE.get(key)
+  const obj = await r2Get(env, key)
   if (!obj) return { value: {} as T, etag: null }
   const value = await obj.json<T>().catch(() => ({}) as T)
   return { value, etag: obj.etag }

--- a/src/cache/r2Get.ts
+++ b/src/cache/r2Get.ts
@@ -1,0 +1,43 @@
+import type { Env } from '../config'
+import { describeError } from '../util/errors'
+
+/**
+ * R2's transient InternalError: "We encountered an internal error. Please try
+ * again. (10001)". workerd surfaces it as a plain Error with the code only in
+ * the message text (no structured code field), so match on that.
+ */
+export function isR2TransientError(err: unknown): boolean {
+  return err instanceof Error && err.message.includes('(10001)')
+}
+
+/**
+ * `STORAGE.get` with one retry on R2's transient InternalError, whose message
+ * itself says to try again. Seen live: a packument rebuild's meta read hit a
+ * 10001 blip, the ref was skipped, and the degraded packument was cached for
+ * PACKUMENT_OUT_TTL_S, failing installs of that version. Any other error
+ * propagates untouched. A second 10001 is rethrown with the object key
+ * attached (the runtime error names only the operation) and the original as
+ * `cause`, so the upstream warn/error log identifies the failing object.
+ */
+export async function r2Get(
+  env: Env,
+  key: string,
+): Promise<R2ObjectBody | null> {
+  try {
+    return await env.STORAGE.get(key)
+  } catch (err) {
+    if (!isR2TransientError(err)) throw err
+    console.warn(
+      `R2 get ${key} hit a transient internal error, retrying once:`,
+      describeError(err),
+    )
+    try {
+      return await env.STORAGE.get(key)
+    } catch (retryErr) {
+      const msg = retryErr instanceof Error ? retryErr.message : String(retryErr)
+      throw new Error(`R2 get ${key} failed after retry: ${msg}`, {
+        cause: retryErr,
+      })
+    }
+  }
+}

--- a/src/preview/getConfiguredRefs.ts
+++ b/src/preview/getConfiguredRefs.ts
@@ -8,6 +8,7 @@ import {
 } from './parseConfiguredPreviewRefs'
 import { REFS_INDEX_KEY } from '../cache/r2Cache'
 import { casR2Json, readR2Json } from '../cache/r2Cas'
+import { describeError } from '../util/errors'
 
 // Runtime-registered refs live in ONE R2 object, read on every packument request
 // with a cheap `get`. The earlier design stored one KV key per ref and read them
@@ -80,7 +81,7 @@ export async function getConfiguredRefsWithEtag(
       })
     }
   } catch (err) {
-    console.warn('Failed to read preview refs from R2:', err)
+    console.warn('Failed to read preview refs from R2:', describeError(err))
   }
 
   return { refs, etag }

--- a/src/preview/metaIndex.ts
+++ b/src/preview/metaIndex.ts
@@ -2,6 +2,7 @@ import type { Env } from '../config'
 import type { PreviewMeta } from '../tarball/buildPreviewTarball'
 import { metaIndexKey, metaKey } from '../cache/r2Cache'
 import { casR2Json, readR2Json } from '../cache/r2Cas'
+import { r2Get } from '../cache/r2Get'
 import { REF_TTL_MS } from './getConfiguredRefs'
 
 /** `0.0.0-commit.<sha>` -> its immutable meta (the same value stored at `metaKey`). */
@@ -30,7 +31,7 @@ export async function resolveVersionMeta(
 ): Promise<PreviewMeta | undefined> {
   const fromIndex = (await readMetaIndex(env, name))[version]
   if (fromIndex) return fromIndex
-  const obj = await env.STORAGE.get(metaKey(name, version))
+  const obj = await r2Get(env, metaKey(name, version))
   if (!obj) return undefined
   return obj.json<PreviewMeta>().catch(() => undefined)
 }

--- a/src/tarball/getPreviewBuild.ts
+++ b/src/tarball/getPreviewBuild.ts
@@ -7,6 +7,7 @@ import {
   tarballContentUrl,
   tarballKey,
 } from '../cache/r2Cache'
+import { r2Get } from '../cache/r2Get'
 import { resolveVersionMeta } from '../preview/metaIndex'
 import type { PreviewMeta } from './buildPreviewTarball'
 
@@ -23,7 +24,7 @@ export async function getPreviewMeta(
   name: string,
   version: string,
 ): Promise<PreviewMeta> {
-  const cached = await env.STORAGE.get(metaKey(name, version))
+  const cached = await r2Get(env, metaKey(name, version))
   if (!cached) {
     throw new HttpError(404, `No published metadata: ${name}@${version}`)
   }
@@ -66,7 +67,7 @@ export async function getPreviewTarballBody(
     // Content-addressed request: a publish always has the CAS object, so this is
     // the hot path (one get) and its bytes are immutable (the URL pins the exact
     // shasum).
-    const cas = await env.STORAGE.get(casKey(name, version, shasum))
+    const cas = await r2Get(env, casKey(name, version, shasum))
     if (cas) return { kind: 'body', body: cas.body, contentLength: cas.size, immutable: true }
     // Migration fallback for an old version-addressed publish action: it stored
     // the bytes at tarballKey and published this same shasum, so serve them for
@@ -80,7 +81,7 @@ export async function getPreviewTarballBody(
     // CAS object and return to the hot path.
     const meta = await resolveVersionMeta(env, name, version)
     if (meta && meta.shasum === shasum) {
-      const legacy = await env.STORAGE.get(tarballKey(name, version))
+      const legacy = await r2Get(env, tarballKey(name, version))
       if (legacy) return { kind: 'body', body: legacy.body, contentLength: legacy.size, immutable: false }
     }
     throw new HttpError(404, `No such tarball: ${name}@${version} (${shasum})`)
@@ -96,7 +97,7 @@ export async function getPreviewTarballBody(
 
   // No published shasum yet: serve legacy version-addressed bytes if present,
   // else 404 (nothing published for this version).
-  const legacy = await env.STORAGE.get(tarballKey(name, version))
+  const legacy = await r2Get(env, tarballKey(name, version))
   if (legacy) return { kind: 'body', body: legacy.body, contentLength: legacy.size, immutable: false }
 
   throw new HttpError(404, `No such tarball: ${name}@${version}`)

--- a/src/util/errors.ts
+++ b/src/util/errors.ts
@@ -1,0 +1,13 @@
+/**
+ * A log-ready description of an error: its stack (which embeds name and
+ * message) plus the `cause` chain. `console.warn('...', err)` renders only
+ * `String(err)` in the Workers logs, dropping the stack and cause, so warn
+ * sites pass this instead. The depth bound keeps a cyclic cause chain from
+ * recursing forever.
+ */
+export function describeError(err: unknown, depth = 0): string {
+  if (!(err instanceof Error)) return String(err)
+  const own = err.stack ?? `${err.name}: ${err.message}`
+  if (err.cause === undefined || depth >= 4) return own
+  return `${own}\nCaused by: ${describeError(err.cause, depth + 1)}`
+}

--- a/test/r2Get.test.ts
+++ b/test/r2Get.test.ts
@@ -1,0 +1,115 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { isR2TransientError, r2Get } from '../src/cache/r2Get'
+import { describeError } from '../src/util/errors'
+import type { Env } from '../src/config'
+
+// R2's transient InternalError as workerd surfaces it: a plain Error whose
+// message carries the operation and the numeric code (seen live from
+// STORAGE.get during a packument rebuild).
+const r2InternalError = () =>
+  new Error('get: We encountered an internal error. Please try again. (10001)')
+
+function envWithGet(get: (key: string) => Promise<unknown>): Env {
+  return { STORAGE: { get } } as unknown as Env
+}
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('isR2TransientError', () => {
+  it('matches the 10001 InternalError message', () => {
+    expect(isR2TransientError(r2InternalError())).toBe(true)
+    expect(
+      isR2TransientError(
+        new Error('put: We encountered an internal error. Please try again. (10001)'),
+      ),
+    ).toBe(true)
+  })
+
+  it('rejects other errors and non-errors', () => {
+    expect(isR2TransientError(new Error('get: The specified object does not exist. (10007)'))).toBe(false)
+    expect(isR2TransientError(new Error('network timeout'))).toBe(false)
+    expect(isR2TransientError('(10001)')).toBe(false)
+    expect(isR2TransientError(undefined)).toBe(false)
+  })
+})
+
+describe('r2Get', () => {
+  it('returns the object without retrying on success', async () => {
+    const obj = { body: 'bytes' }
+    const get = vi.fn(async () => obj)
+    const result = await r2Get(envWithGet(get), 'meta/pkg/1.0.0')
+    expect(result).toBe(obj)
+    expect(get).toHaveBeenCalledTimes(1)
+  })
+
+  it('retries once on 10001 and returns the second result', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const obj = { body: 'bytes' }
+    const get = vi
+      .fn()
+      .mockRejectedValueOnce(r2InternalError())
+      .mockResolvedValueOnce(obj)
+    const result = await r2Get(envWithGet(get), 'meta/pkg/1.0.0')
+    expect(result).toBe(obj)
+    expect(get).toHaveBeenCalledTimes(2)
+    expect(get).toHaveBeenNthCalledWith(2, 'meta/pkg/1.0.0')
+    // The retry itself is logged with the key and the full error detail.
+    expect(warn).toHaveBeenCalledTimes(1)
+    const logged = warn.mock.calls[0].join(' ')
+    expect(logged).toContain('meta/pkg/1.0.0')
+    expect(logged).toContain('(10001)')
+  })
+
+  it('does not retry non-transient errors', async () => {
+    const notFound = new Error('get: The specified bucket does not exist. (10006)')
+    const get = vi.fn().mockRejectedValue(notFound)
+    await expect(r2Get(envWithGet(get), 'meta/pkg/1.0.0')).rejects.toBe(notFound)
+    expect(get).toHaveBeenCalledTimes(1)
+  })
+
+  it('rethrows with the key attached when the retry also fails', async () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const second = r2InternalError()
+    const get = vi
+      .fn()
+      .mockRejectedValueOnce(r2InternalError())
+      .mockRejectedValueOnce(second)
+    const err = await r2Get(envWithGet(get), 'meta/pkg/1.0.0').then(
+      () => {
+        throw new Error('expected r2Get to reject')
+      },
+      (e: unknown) => e as Error,
+    )
+    expect(get).toHaveBeenCalledTimes(2)
+    expect(err.message).toContain('meta/pkg/1.0.0')
+    expect(err.message).toContain('failed after retry')
+    expect(err.message).toContain('(10001)')
+    expect(err.cause).toBe(second)
+  })
+})
+
+describe('describeError', () => {
+  it('includes the stack (name + message) of the error', () => {
+    const detail = describeError(new Error('boom'))
+    expect(detail).toContain('Error: boom')
+    expect(detail).toContain('at ') // stack frames
+  })
+
+  it('walks the cause chain', () => {
+    const root = r2InternalError()
+    const wrapped = new Error('R2 get meta/pkg/1.0.0 failed after retry', {
+      cause: root,
+    })
+    const detail = describeError(wrapped)
+    expect(detail).toContain('failed after retry')
+    expect(detail).toContain('Caused by:')
+    expect(detail).toContain('(10001)')
+  })
+
+  it('stringifies non-Error values', () => {
+    expect(describeError('plain string')).toBe('plain string')
+    expect(describeError(undefined)).toBe('undefined')
+  })
+})


### PR DESCRIPTION
Production logs showed packument rebuilds hitting R2's transient InternalError:

```
[warn] Failed to inject preview ref 0.0.0-commit.affd11e...: Error: get: We encountered an internal error. Please try again. (10001)
```

When that happened, the preview version dropped out of the served packument and the degraded result was cached for `PACKUMENT_OUT_TTL_S` (60s), so installs of that version failed with "version not found".

Changes:

- New `r2Get(env, key)` helper wraps `STORAGE.get` and retries once when the error message carries R2's 10001 code (the message itself says "Please try again"). Other errors propagate untouched. A second 10001 is rethrown with the object key attached and the original error as `cause`, since the raw R2 error only names the operation.
- All six R2 `get` call sites now go through the helper: the refs index and meta aggregate reads (`readR2Json`), `getPreviewMeta`, the three gets in `getPreviewTarballBody`, and `resolveVersionMeta`.
- Warn/error sites log detailed errors via `describeError` (stack plus cause chain). `console.warn('...', err)` renders only `String(err)` in Workers logs, which is why the log line above had no stack or key. The inject warn also names the package now.

Tests cover: no retry on success, retry-once-then-succeed on 10001, no retry for non-transient errors, key and cause attached after a double failure, and the `describeError` output.