### PR TITLE
fix: serve registered preview versions by exact URL

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -22,6 +22,7 @@ import {
 import {
   parseNpmTarballPath,
   parsePackagePath,
+  parsePackageVersionPath,
   parsePkgPrNewDownload,
   parseTarballPath,
   parseUploadPath,
@@ -436,6 +437,27 @@ app.get('*', async (c) => {
   const download = parsePkgPrNewDownload(pathname, c.env.PREVIEW_OWNER, c.env.PREVIEW_REPO)
   if (download) {
     return await serveDownloadRedirect(c.env, download, c.req.method === 'HEAD')
+  }
+
+  // npm package-version endpoint (`/<name>/<version>`). Some clients fetch a
+  // version document directly after resolution instead of reading it only from
+  // the packument. Serve registered preview metadata from R2; normal versions
+  // and packages still go to npm unchanged.
+  const packageVersion = parsePackageVersionPath(pathname)
+  if (packageVersion) {
+    const { name, version } = packageVersion
+    if (!isWorkspacePackage(name, c.env) || !parsePreviewVersion(version)) {
+      return redirectToNpm(c.env, c.req.raw)
+    }
+
+    const [refs, preview] = await Promise.all([
+      getConfiguredRefs(c.env),
+      resolveVersionMeta(c.env, name, version),
+    ])
+    if (!refs.some((ref) => ref.version === version) || !preview) {
+      throw new HttpError(404, `Version not found: ${name}@${version}`)
+    }
+    return packumentResponse(JSON.stringify(buildVersionMetadata(c.env, name, version, preview)))
   }
 
   const pkgReq = parsePackagePath(pathname)

--- a/src/registry/parsePackageName.ts
+++ b/src/registry/parsePackageName.ts
@@ -14,6 +14,10 @@ export interface PackumentRequest {
   name: string
 }
 
+export interface PackageVersionRequest extends PackumentRequest {
+  version: string
+}
+
 /** Strip leading slashes and percent-decode a request path; null if malformed. */
 function decodePath(pathname: string): string | null {
   try {
@@ -46,6 +50,26 @@ export function parsePackagePath(pathname: string): PackumentRequest | null {
   // Unscoped: a single segment.
   if (segments.length !== 1 || !segments[0]) return null
   return { name: segments[0] }
+}
+
+/**
+ * Identify an npm package-version request:
+ *   /vite-plus/0.0.0-commit.<sha>
+ *   /@voidzero-dev/vite-plus-core/0.0.0-commit.<sha>
+ *   /@voidzero-dev%2Fvite-plus-core/0.0.0-commit.<sha>
+ */
+export function parsePackageVersionPath(pathname: string): PackageVersionRequest | null {
+  const decoded = decodePath(pathname)
+  if (!decoded || decoded.includes('/-/') || decoded.startsWith('-/')) return null
+
+  const segments = decoded.split('/')
+  if (decoded.startsWith('@')) {
+    if (segments.length !== 3 || segments.some((segment) => !segment)) return null
+    return { name: `${segments[0]}/${segments[1]}`, version: segments[2] }
+  }
+
+  if (segments.length !== 2 || segments.some((segment) => !segment)) return null
+  return { name: segments[0], version: segments[1] }
 }
 
 export interface TarballRequest {

--- a/test/unit.test.ts
+++ b/test/unit.test.ts
@@ -8,6 +8,7 @@ import {
   encodeNpmPackageName,
   parseNpmTarballPath,
   parsePackagePath,
+  parsePackageVersionPath,
   parseTarballPath,
 } from '../src/registry/parsePackageName'
 import { rewritePackageJson } from '../src/tarball/rewritePackageJson'
@@ -108,6 +109,36 @@ describe('parsePackagePath', () => {
     expect(parsePackagePath('/vite/-/vite-5.0.0.tgz')).toBeNull()
     expect(parsePackagePath('/@scope/name/-/name-1.0.0.tgz')).toBeNull()
     expect(parsePackagePath('/-/v1/search?text=vite')).toBeNull()
+  })
+})
+
+describe('parsePackageVersionPath', () => {
+  it('parses unscoped, scoped, and encoded-scoped package versions', () => {
+    expect(parsePackageVersionPath('/vite-plus/0.0.0-commit.a832a55')).toEqual({
+      name: 'vite-plus',
+      version: '0.0.0-commit.a832a55',
+    })
+    expect(
+      parsePackageVersionPath(
+        '/@voidzero-dev/vite-plus-core/0.0.0-commit.0123456789abcdef0123456789abcdef01234567',
+      ),
+    ).toEqual({
+      name: '@voidzero-dev/vite-plus-core',
+      version: '0.0.0-commit.0123456789abcdef0123456789abcdef01234567',
+    })
+    expect(parsePackageVersionPath('/@voidzero-dev%2Fvite-plus-core/0.0.0-commit.a832a55')).toEqual(
+      {
+        name: '@voidzero-dev/vite-plus-core',
+        version: '0.0.0-commit.a832a55',
+      },
+    )
+  })
+
+  it('returns null for packument, tarball, api, and malformed paths', () => {
+    expect(parsePackageVersionPath('/vite-plus')).toBeNull()
+    expect(parsePackageVersionPath('/vite-plus/-/vite-plus-1.0.0.tgz')).toBeNull()
+    expect(parsePackageVersionPath('/-/v1/search')).toBeNull()
+    expect(parsePackageVersionPath('/vite-plus/')).toBeNull()
   })
 })
 

--- a/test/worker.test.ts
+++ b/test/worker.test.ts
@@ -496,6 +496,77 @@ describe('packument endpoint', () => {
   })
 })
 
+describe('package version endpoint', () => {
+  it('serves a published preview version', async () => {
+    const res = await SELF.fetch(`${BASE}/vite-plus/${FIXTURE_VERSION}`, {
+      headers: { accept: 'application/json' },
+    })
+    expect(res.status).toBe(200)
+    expect(res.headers.get('content-type')).toContain('application/json')
+
+    const body = (await res.json()) as Record<string, any>
+    expect(body.name).toBe('vite-plus')
+    expect(body.version).toBe(FIXTURE_VERSION)
+    expect(body.dependencies['@voidzero-dev/vite-plus-core']).toBe(FIXTURE_VERSION)
+    expect(body.dist.tarball).toBe(
+      `${BASE}/tarballs/vite-plus/${FIXTURE_VERSION}/${fixtureShasum['vite-plus']}.tgz`,
+    )
+  })
+
+  it('serves an encoded scoped package version', async () => {
+    const name = '@voidzero-dev/vite-plus-core'
+    const res = await SELF.fetch(`${BASE}/@voidzero-dev%2Fvite-plus-core/${FIXTURE_VERSION}`)
+    expect(res.status).toBe(200)
+
+    const body = (await res.json()) as Record<string, any>
+    expect(body.name).toBe(name)
+    expect(body.version).toBe(FIXTURE_VERSION)
+    expect(body.dist.tarball).toBe(
+      `${BASE}/tarballs/${name}/${FIXTURE_VERSION}/${fixtureShasum[name]}.tgz`,
+    )
+  })
+
+  it('404s a preview version with no published metadata', async () => {
+    const version = '0.0.0-commit.deadbeef'
+    const res = await SELF.fetch(`${BASE}/vite-plus/${version}`)
+    expect(res.status).toBe(404)
+    await expect(res.json()).resolves.toEqual({ error: `Version not found: vite-plus@${version}` })
+  })
+
+  it('keeps a published version hidden until its ref is registered', async () => {
+    const sha = 'adeadbeef'
+    const version = `0.0.0-commit.${sha}`
+    const publish = await SELF.fetch(`${BASE}/-/publish`, {
+      method: 'POST',
+      headers: { ...AUTH, 'content-type': 'application/json' },
+      body: JSON.stringify({
+        ref: `commit.${sha}`,
+        packages: [
+          {
+            name: 'vite-plus',
+            version,
+            packageJson: { name: 'vite-plus', version },
+          },
+        ],
+      }),
+    })
+    expect(publish.status).toBe(201)
+
+    const res = await SELF.fetch(`${BASE}/vite-plus/${version}`)
+    expect(res.status).toBe(404)
+  })
+
+  it('redirects normal and non-allowlisted versions to npm', async () => {
+    const normal = await SELF.fetch(`${BASE}/vite-plus/0.2.1`, { redirect: 'manual' })
+    expect(normal.status).toBe(302)
+    expect(normal.headers.get('location')).toBe('https://registry.npmjs.org/vite-plus/0.2.1')
+
+    const other = await SELF.fetch(`${BASE}/react/19.0.0`, { redirect: 'manual' })
+    expect(other.status).toBe(302)
+    expect(other.headers.get('location')).toBe('https://registry.npmjs.org/react/19.0.0')
+  })
+})
+
 describe('tarball endpoint', () => {
   it('serves a generated commit tarball with rewritten package.json and immutable cache', async () => {
     // The packument advertises the content URL (shasum in the path); fetch that


### PR DESCRIPTION
Package clients can now request a registered preview version at `/<package>/<version>`. The Worker reads the version metadata from R2. It returns the same `dist` data as the packument.

The new path parser supports unscoped, scoped, and encoded scoped package names. The Worker sends normal versions and other packages to npm. It returns 404 for a missing or unregistered preview version.

Tests cover the parser, exact-version responses, registration visibility, missing metadata, and npm redirects.